### PR TITLE
Improve ci with dotnet-releaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,8 @@ jobs:
       with:
         dotnet-version: '6.0.x'
 
-    - name: Build and Test (Debug)
-      run: dotnet test -c Debug
-
-    - name: Self Build - Publish (main only)
+    - name: Build, Test (Debug & Release), Publish (main only)
       shell: bash
       run: |
         dotnet tool install --global dotnet-releaser
-        dotnet-releaser publish --force  --nuget-token ${{secrets.NUGET_TOKEN}} --github-token ${{secrets.GITHUB_TOKEN}} dotnet-releaser.toml
+        dotnet-releaser run --nuget-token "${{secrets.NUGET_TOKEN}}" --github-token "${{secrets.GITHUB_TOKEN}}" dotnet-releaser.toml

--- a/dotnet-releaser.toml
+++ b/dotnet-releaser.toml
@@ -1,6 +1,11 @@
 # configuration file for dotnet-releaser
 [msbuild]
 project = "MonorailCss.sln"
+build_debug = true
+[test]
+run_tests_for_debug = true
+[nuget]
+publish_draft = true # publish draft NuGet package per commit
 [github]
 user = "phil-scott-78"
 repo = "monorail"


### PR DESCRIPTION
Hey, 

this is a small PR to improve the usage of dotnet-releaser (thank you for using it! 🙂 )

* Adding build and test in Debug to dotnet-releaser (so that coverage takes it into account as well)
* Use `dotnet-releaser run` so that it builds on regular commits and publish only when there is a tag and it is the main branch