### PR TITLE
fix(utilities): emit arbitrary var()/opaque colors for text-

### DIFF
--- a/src/MonorailCss/DataTypes/DataTypeInference.cs
+++ b/src/MonorailCss/DataTypes/DataTypeInference.cs
@@ -401,6 +401,20 @@ internal static partial class DataTypeInference
     }
 
     /// <summary>
+    /// Checks if a value is an opaque CSS-function expression whose type cannot be
+    /// introspected at compile time (e.g. <c>var()</c>, <c>theme()</c>, <c>color-mix()</c>,
+    /// <c>light-dark()</c>). Color utilities treat these as colors because their namespace
+    /// already commits to color semantics — see <see cref="InferDataType"/> bailing on <c>var(</c>.
+    /// </summary>
+    public static bool IsOpaqueColorExpression(string value)
+    {
+        return value.StartsWith("var(", StringComparison.Ordinal)
+            || value.StartsWith("theme(", StringComparison.Ordinal)
+            || value.StartsWith("color-mix(", StringComparison.Ordinal)
+            || value.StartsWith("light-dark(", StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// Checks if a value contains CSS math functions.
     /// </summary>
     public static bool HasMathFunction(string value)

--- a/src/MonorailCss/Utilities/Base/BaseColorUtility.cs
+++ b/src/MonorailCss/Utilities/Base/BaseColorUtility.cs
@@ -79,7 +79,7 @@ internal abstract class BaseColorUtility : IUtility
                 // and theme() where inference can't tell us the type — the
                 // utility's namespace (bg, text, border-color, …) implies color.
                 var arbitrary = resolvedCandidate.Value;
-                if (!IsOpaqueColorExpression(arbitrary))
+                if (!DataTypeInference.IsOpaqueColorExpression(arbitrary))
                 {
                     var inferredType = DataTypeInference.InferDataType(
                         arbitrary,
@@ -109,18 +109,6 @@ internal abstract class BaseColorUtility : IUtility
     protected virtual bool TryResolveColor(CandidateValue value, Theme.Theme theme, [NotNullWhen(true)] out string? color)
     {
         return ValueResolver.TryResolveColor(value, theme, ColorNamespaces, out color);
-    }
-
-    // Treat opaque CSS-function values as colors when no type hint is given.
-    // The utility's namespace already commits to color semantics; without this
-    // we'd reject `bg-[var(--my-color)]` because the inference engine can't
-    // peek inside `var()` to detect a color.
-    private static bool IsOpaqueColorExpression(string value)
-    {
-        return value.StartsWith("var(", StringComparison.Ordinal)
-            || value.StartsWith("theme(", StringComparison.Ordinal)
-            || value.StartsWith("color-mix(", StringComparison.Ordinal)
-            || value.StartsWith("light-dark(", StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/src/MonorailCss/Utilities/Typography/FontFamilyUtility.cs
+++ b/src/MonorailCss/Utilities/Typography/FontFamilyUtility.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 using MonorailCss.Ast;
+using MonorailCss.Candidates;
+using MonorailCss.DataTypes;
 using MonorailCss.Utilities.Base;
 
 namespace MonorailCss.Utilities.Typography;
@@ -15,33 +17,51 @@ internal class FontFamilyUtility : BaseFunctionalUtility
     protected override string[] ThemeKeys => ["--font"];
 
     /// <summary>
-    /// Check if a value represents a font-family (not font-weight).
+    /// Routes arbitrary values: only family/generic values become a font-family.
+    /// Numbers, var()/calc() and other type hints fall through (return false) so
+    /// <see cref="FontWeightUtility"/> handles them as font-weight — matching Tailwind,
+    /// where `font` infers ['number','generic-name','family-name'] and only the last
+    /// two map to font-family.
     /// </summary>
-    private static bool IsFontFamilyValue(string value)
+    protected override bool TryResolveValue(CandidateValue value, Theme.Theme theme, bool isNegative, out string resolvedValue)
     {
-        // If it's a numeric value or known weight name, it's font-weight
-        if (int.TryParse(value, out _) || IsWeightName(value))
+        if (value.Kind == ValueKind.Arbitrary)
+        {
+            resolvedValue = string.Empty;
+            if (!AcceptsAsFamily(value))
+            {
+                return false;
+            }
+
+            resolvedValue = value.Value;
+            return true;
+        }
+
+        return base.TryResolveValue(value, theme, isNegative, out resolvedValue);
+    }
+
+    /// <summary>
+    /// Determines whether an arbitrary value should be treated as a font-family.
+    /// </summary>
+    private static bool AcceptsAsFamily(CandidateValue value)
+    {
+        if (value.DataTypeHint is "family-name" or "generic-name")
+        {
+            return true;
+        }
+
+        // Any other explicit hint (length, number, color, …) belongs to a sibling utility.
+        if (value.DataTypeHint != null)
         {
             return false;
         }
 
-        // For other values, assume it's font-family if it's not obviously weight
-        // This allows custom font families like "display", "body", "code" etc.
-        return true;
-    }
-
-    /// <summary>
-    /// Check if a value is a font-weight name.
-    /// </summary>
-    private static bool IsWeightName(string value)
-    {
-        var weightNames = new HashSet<string>
-        {
-            "thin", "extralight", "light", "normal", "medium",
-            "semibold", "bold", "extrabold", "black",
-        };
-
-        return weightNames.Contains(value);
+        // No hint: infer. var()/calc() resolve to null here, so they fall through
+        // to font-weight just like bare numbers do.
+        var inferred = DataTypeInference.InferDataType(
+            value.Value,
+            [DataType.Number, DataType.GenericName, DataType.FamilyName]);
+        return inferred is DataType.FamilyName or DataType.GenericName;
     }
 
     protected override ImmutableList<AstNode> GenerateDeclarations(string pattern, string value, bool important)

--- a/src/MonorailCss/Utilities/Typography/FontWeightUtility.cs
+++ b/src/MonorailCss/Utilities/Typography/FontWeightUtility.cs
@@ -106,6 +106,22 @@ internal class FontWeightUtility : BaseFunctionalUtility
     }
 
     /// <summary>
+    /// Routes arbitrary values: defer family-name/generic-name hints to
+    /// <see cref="FontFamilyUtility"/>; everything else (numbers, var(), calc())
+    /// is validated as a font-weight by the base via <see cref="IsValidArbitraryValue"/>.
+    /// </summary>
+    protected override bool TryResolveValue(CandidateValue value, Theme.Theme theme, bool isNegative, out string resolvedValue)
+    {
+        if (value.Kind == ValueKind.Arbitrary && value.DataTypeHint is "family-name" or "generic-name")
+        {
+            resolvedValue = string.Empty;
+            return false;
+        }
+
+        return base.TryResolveValue(value, theme, isNegative, out resolvedValue);
+    }
+
+    /// <summary>
     /// Validates arbitrary values for font-weight.
     /// </summary>
     protected override bool IsValidArbitraryValue(string value)

--- a/src/MonorailCss/Utilities/Typography/TextUtility.cs
+++ b/src/MonorailCss/Utilities/Typography/TextUtility.cs
@@ -41,12 +41,14 @@ internal class TextUtility : IUtility
         // Handle arbitrary values
         if (functionalUtility.Value.Kind == ValueKind.Arbitrary)
         {
+            // Substitute `theme(...)` calls up-front so the hint check and
+            // inference below operate on a concrete value (mirrors BaseColorUtility).
+            value = ValueResolver.SubstituteThemeFunctions(value, theme);
+
             var hint = functionalUtility.Value.DataTypeHint;
 
             // Type-hint dispatch: `text-[length:var(--x)]` forces font-size,
-            // `text-[color:var(--x)]` forces color. Without a hint we fall back
-            // to inference, accepting opaque CSS functions (var(), theme(), …)
-            // as colors since the namespace defaults to color.
+            // `text-[color:var(--x)]` forces color.
             if (hint != null)
             {
                 switch (hint)
@@ -71,6 +73,22 @@ internal class TextUtility : IUtility
                     default:
                         return false;
                 }
+            }
+
+            // No hint: opaque CSS functions (var(), color-mix(), light-dark()) can't
+            // be introspected by the inference engine. The text namespace defaults to
+            // color, so treat them as colors — keeping text-[var(--x)] symmetric with
+            // bg-[var(--x)] / border-[var(--x)].
+            if (DataTypeInference.IsOpaqueColorExpression(value))
+            {
+                if (TryApplyColorWithModifier(value, candidate.Modifier, theme, out var opaqueColor))
+                {
+                    results = ImmutableList.Create<AstNode>(
+                        new Declaration("color", opaqueColor, candidate.Important));
+                    return true;
+                }
+
+                return false;
             }
 
             var inferredType = DataTypeInference.InferDataType(

--- a/tests/MonorailCss.Tests/CssFrameworkTests.cs
+++ b/tests/MonorailCss.Tests/CssFrameworkTests.cs
@@ -128,6 +128,45 @@ public partial class CssFrameworkTests
     }
 
     [Fact]
+    public void Process_ShouldEmitArbitraryVarValues_ForTextSymmetricallyWithBgAndBorder()
+    {
+        // Regression: bare var() emitted for bg-/border- but was silently dropped for text-.
+        var testCases = new[]
+        {
+            ("bg-[var(--x)]", "background-color: var(--x)"),
+            ("border-[var(--x)]", "border-color: var(--x)"),
+            ("text-[var(--x)]", "color: var(--x)"),
+            ("text-[color:var(--x)]", "color: var(--x)"),
+        };
+
+        foreach (var (input, expected) in testCases)
+        {
+            _framework.Process(input).ShouldContain(expected);
+        }
+    }
+
+    [Fact]
+    public void Process_ShouldHonorVariantAndOpacityModifier_OnArbitraryTextVar()
+    {
+        var hover = _framework.Process("hover:text-[var(--oxblood)]");
+        hover.ShouldContain("color: var(--oxblood)");
+        hover.ShouldContain(":hover");
+
+        _framework.Process("text-[var(--oxblood)]/50")
+            .ShouldContain("color-mix(in oklab, var(--oxblood) 50%, transparent)");
+    }
+
+    [Fact]
+    public void Process_ShouldRouteArbitraryFontValues_LikeTailwind()
+    {
+        // Bare var()/number -> font-weight; family-name/generic-name hint or inferred family -> font-family.
+        _framework.Process("font-[var(--x)]").ShouldContain("font-weight: var(--x)");
+        _framework.Process("font-[600]").ShouldContain("font-weight: 600");
+        _framework.Process("font-[family-name:var(--x)]").ShouldContain("font-family: var(--x)");
+        _framework.Process("font-[Helvetica]").ShouldContain("font-family: Helvetica");
+    }
+
+    [Fact]
     public void Process_ShouldHandleArbitraryGradientBackgroundImage()
     {
         var testCases = new[]

--- a/tests/MonorailCss.Tests/canonical-v4.json
+++ b/tests/MonorailCss.Tests/canonical-v4.json
@@ -46248,6 +46248,18 @@
       "font-family"
     ]
   },
+  "font-[var(--my-family)]": {
+    "css": "font-weight: var(--my-family);",
+    "cssProperties": [
+      "font-weight"
+    ]
+  },
+  "font-[600]": {
+    "css": "font-weight: 600;",
+    "cssProperties": [
+      "font-weight"
+    ]
+  },
   "text-2xl": {
     "css": "font-size: var(--text-2xl);\n    line-height: var(--tw-leading, var(--text-2xl--line-height));",
     "cssProperties": [
@@ -46493,6 +46505,12 @@
     ]
   },
   "text-[color:var(--my-color)]": {
+    "css": "color: var(--my-color);",
+    "cssProperties": [
+      "color"
+    ]
+  },
+  "text-[var(--my-color)]": {
     "css": "color: var(--my-color);",
     "cssProperties": [
       "color"


### PR DESCRIPTION
`text-[var(--x)]` was silently dropped while `bg-[var(--x)]`/`border-[var(--x)]` worked: TextUtility ran every arbitrary value through DataTypeInference, which bails on `var(`, then returned false. BaseColorUtility had a private IsOpaqueColorExpression() the text path never shared, so the two color paths drifted.

- DataTypeInference: add shared IsOpaqueColorExpression() (var/theme/color-mix/light-dark)
- BaseColorUtility: delegate to the shared helper
- TextUtility: substitute theme() up front; treat opaque color expressions as color before inference -> text-[var(--x)], hover:text-[var(--x)], text-[var(--x)]/50
- Font: route arbitrary values like Tailwind via TryResolveValue overrides -- bare var()/number -> font-weight; family-name/generic-name hint or inferred family/generic -> font-family (fixes font-[600] -> font-weight, previously the invalid font-family: 600)

Tests: canonical-v4.json entries for text-[var(--my-color)], font-[var(--my-family)], font-[600]; focused CssFrameworkTests covering bg/border/text symmetry, hover variant, /50 opacity modifier, and font routing.