### PR TITLE
fix(variants): add min-*/max-* breakpoints; fix Applies pseudo-element + raw-CSS docs

### DIFF
--- a/src/MonorailCss/CssFrameworkSettings.cs
+++ b/src/MonorailCss/CssFrameworkSettings.cs
@@ -48,7 +48,11 @@ public record CssFrameworkSettings
     public bool IncludePreflight { get; init; }
 
     /// <summary>
-    /// Gets a map of custom apply rules where the key is a selector or alias and the value is a space-separated list of utilities or raw CSS to apply.
+    /// Gets a map of custom apply rules where the key is a CSS selector (or alias) and the value is a
+    /// space-separated list of utility class names to apply. Each utility may carry variants such as
+    /// <c>hover:</c> or <c>md:</c>. Raw CSS declarations are <b>not</b> supported (mirroring Tailwind's
+    /// <c>@apply</c>, which accepts utilities only); use arbitrary-value utilities like
+    /// <c>bg-[color-mix(in_oklab,red,blue)]</c> to emit literal values.
     /// </summary>
     public ImmutableDictionary<string, string> Applies { get; init; }
 

--- a/src/MonorailCss/Processing/ApplyProcessor.cs
+++ b/src/MonorailCss/Processing/ApplyProcessor.cs
@@ -39,6 +39,32 @@ internal class ApplyProcessor
     }
 
     /// <summary>
+    /// Splits a trailing pseudo-element (e.g. <c>::after</c>) off the end of an Applies selector key
+    /// so variants can be composed against the base selector and the pseudo-element re-appended last
+    /// (pseudo-elements must always terminate a selector). Returns the original selector with an
+    /// empty pseudo-element when there is no terminal pseudo-element.
+    /// </summary>
+    private static (string Base, string PseudoElement) SplitTrailingPseudoElement(string selector)
+    {
+        var idx = selector.IndexOf("::", StringComparison.Ordinal);
+        if (idx < 0)
+        {
+            return (selector, string.Empty);
+        }
+
+        var pseudo = selector[idx..];
+
+        // Only treat it as a terminal pseudo-element; anything with a combinator after it is a
+        // more complex selector we leave untouched.
+        if (pseudo.Contains(' ') || pseudo.Contains('>'))
+        {
+            return (selector, string.Empty);
+        }
+
+        return (selector[..idx], pseudo);
+    }
+
+    /// <summary>
     /// Converts an AppliedSelector (which uses class selector format) to component selector format.
     /// </summary>
     private static string ConvertAppliedSelectorToComponentSelector(AppliedSelector appliedSelector, string componentSelector)
@@ -235,14 +261,19 @@ internal class ApplyProcessor
                 {
                     var firstCandidate = group[0].Candidate;
 
+                    // A trailing pseudo-element in the key (e.g. ".card::after") must be composed
+                    // against the base selector and re-appended last, otherwise variants append
+                    // their fragments after the pseudo-element and the pseudo-element is doubled.
+                    var (selectorBase, pseudoElement) = SplitTrailingPseudoElement(selector);
+
                     // Use the VariantRegistry to apply variants properly
                     // For descendant selectors, we need to pass them properly to the variant system
                     AppliedSelector appliedSelector;
-                    if (selector.Contains(' '))
+                    if (selectorBase.Contains(' '))
                     {
                         // For descendant selectors, create an AppliedSelector directly with the full selector
                         // Don't use FromClass since it's not a simple class name
-                        appliedSelector = AppliedSelector.FromSelector(new Selector(selector));
+                        appliedSelector = AppliedSelector.FromSelector(new Selector(selectorBase));
 
                         // Now apply the variants to this selector
                         foreach (var variant in firstCandidate.Variants)
@@ -263,12 +294,12 @@ internal class ApplyProcessor
                     else
                     {
                         // Simple class selector - use the existing logic
-                        var baseSelector = selector.StartsWith(".") ? selector.Substring(1) : selector;
+                        var baseSelector = selectorBase.StartsWith(".") ? selectorBase.Substring(1) : selectorBase;
                         appliedSelector = _variantRegistry.ApplyVariants(baseSelector, firstCandidate.Variants);
                     }
 
                     // Extract the final selector and handle any at-rule wrappers
-                    var finalSelector = ConvertAppliedSelectorToComponentSelector(appliedSelector, selector);
+                    var finalSelector = ConvertAppliedSelectorToComponentSelector(appliedSelector, selectorBase) + pseudoElement;
                     var styleRule = new StyleRule(finalSelector, mergedDeclarations.Cast<AstNode>().ToImmutableList());
 
                     // Wrap in any at-rules (media queries, supports, etc.)

--- a/src/MonorailCss/Variants/BuiltIn/BreakpointRangeVariant.cs
+++ b/src/MonorailCss/Variants/BuiltIn/BreakpointRangeVariant.cs
@@ -1,0 +1,71 @@
+using MonorailCss.Css;
+
+namespace MonorailCss.Variants.BuiltIn;
+
+/// <summary>
+/// Variant for functional responsive breakpoints: <c>min-*</c> and <c>max-*</c>.
+/// The value is either an arbitrary length (<c>min-[1100px]</c>) or a named breakpoint resolved
+/// from the <c>--breakpoint-*</c> theme namespace (<c>min-tablet</c>, <c>max-lg</c>).
+/// Output matches Tailwind v4: <c>min-*</c> emits <c>@media (min-width: X)</c> and <c>max-*</c>
+/// emits <c>@media not all and (min-width: X)</c> (exclusive upper bound).
+/// </summary>
+internal sealed class BreakpointRangeVariant : IVariant
+{
+    private readonly bool _isMax;
+    private readonly Theme.Theme _theme;
+
+    public BreakpointRangeVariant(string name, bool isMax, Theme.Theme theme, int weight)
+    {
+        Name = name;
+        _isMax = isMax;
+        _theme = theme;
+        Weight = weight;
+    }
+
+    public string Name { get; }
+
+    public int Weight { get; }
+
+    public VariantKind Kind => VariantKind.Functional;
+
+    public VariantConstraints Constraints => VariantConstraints.Any;
+
+    public bool CanHandle(VariantToken token) =>
+        token.Name == Name && token.Value != null;
+
+    public bool TryApply(AppliedSelector current, VariantToken token, out AppliedSelector result)
+    {
+        result = current;
+
+        if (!CanHandle(token))
+        {
+            return false;
+        }
+
+        var value = token.Value!;
+
+        // Arbitrary length (e.g. min-[1100px]) takes the literal inside the brackets;
+        // otherwise resolve a named breakpoint from the --breakpoint-* theme namespace.
+        string? width;
+        if (value.StartsWith('[') && value.EndsWith(']'))
+        {
+            width = value[1..^1];
+        }
+        else
+        {
+            width = _theme.ResolveValue(value, ["--breakpoint"]);
+        }
+
+        if (string.IsNullOrEmpty(width))
+        {
+            return false;
+        }
+
+        var query = _isMax
+            ? $"not all and (min-width: {width})"
+            : $"(min-width: {width})";
+
+        result = current.WithWrapper(AtRuleWrapper.Media(query));
+        return true;
+    }
+}

--- a/src/MonorailCss/Variants/VariantRegistry.cs
+++ b/src/MonorailCss/Variants/VariantRegistry.cs
@@ -258,6 +258,11 @@ internal sealed class VariantRegistry
         Register(new BreakpointVariant("xl", "(min-width: 1280px)", 630));
         Register(new BreakpointVariant("2xl", "(min-width: 1536px)", 640));
 
+        // Functional responsive breakpoints: min-[1100px], max-[1100px], min-tablet, max-lg, etc.
+        // (per-value ordering within min/max is not modeled by the single-weight system).
+        Register(new BreakpointRangeVariant("min", isMax: false, theme, 641));
+        Register(new BreakpointRangeVariant("max", isMax: true, theme, 648));
+
         Register(new PrintVariant(650));
         Register(new ContrastVariant("contrast-more", 660));
         Register(new ContrastVariant("contrast-less", 670));

--- a/src/MonorailCss/Variants/VariantToken.cs
+++ b/src/MonorailCss/Variants/VariantToken.cs
@@ -47,7 +47,7 @@ public readonly record struct VariantToken(
     /// <summary>
     /// Gets a value indicating whether checks if this is a media query variant.
     /// </summary>
-    public bool IsMediaQuery => Raw.StartsWith("[@media") || Name is "sm" or "md" or "lg" or "xl" or "2xl";
+    public bool IsMediaQuery => Raw.StartsWith("[@media") || Name is "sm" or "md" or "lg" or "xl" or "2xl" or "min" or "max";
 
     /// <summary>
     /// Gets a value indicating whether checks if this is a container query variant.

--- a/src/MonorailCss/Variants/VariantTokenizer.cs
+++ b/src/MonorailCss/Variants/VariantTokenizer.cs
@@ -126,6 +126,14 @@ internal class VariantTokenizer
             return VariantToken.Static(containerRoot);
         }
 
+        // Check for functional responsive breakpoints (min-*, max-*). The value keeps its
+        // brackets so the variant can distinguish arbitrary lengths (min-[1100px]) from named
+        // breakpoints (min-tablet) resolved against --breakpoint-*.
+        if (segment.StartsWith("min-") || segment.StartsWith("max-"))
+        {
+            return VariantToken.Functional(segment[..3], segment[4..]);
+        }
+
         // Check for media query breakpoints
         if (IsBreakpointVariant(segment))
         {
@@ -255,7 +263,9 @@ internal class VariantTokenizer
     /// </summary>
     private bool IsBreakpointVariant(string segment)
     {
+        // Note: min-*/max-* are handled earlier as functional breakpoint variants; the bare
+        // "min"/"max" words are not breakpoints on their own.
         return segment is "sm" or "md" or "lg" or "xl" or "2xl" or
-               "min" or "max" or "portrait" or "landscape";
+               "portrait" or "landscape";
     }
 }

--- a/tests/MonorailCss.Tests/AppliesIntegrationTest.cs
+++ b/tests/MonorailCss.Tests/AppliesIntegrationTest.cs
@@ -332,4 +332,48 @@ public class AppliesIntegrationTest
         result.ShouldContain(".btn .inner:where(.dark, .dark *) {");
 
     }
+
+    [Fact]
+    public void Process_WithRawCssAppliesValue_EmitsNothing()
+    {
+        // Applies values are utility class names only (matching Tailwind's @apply). Raw CSS
+        // declarations are not parsed and produce no output; arbitrary-value utilities are the
+        // supported way to emit literal values.
+        var settings = new CssFrameworkSettings
+        {
+            IncludePreflight = false,
+            Applies = ImmutableDictionary<string, string>.Empty
+                .Add(".p-shard-file", "background: red; border: 1px solid black;")
+        };
+
+        var framework = new CssFramework(settings);
+
+        var result = framework.Process("");
+        Console.WriteLine(result);
+
+        // The raw declarations are ignored entirely (treated as unknown utilities).
+        result.ShouldNotContain("background: red");
+        result.ShouldNotContain("border: 1px solid black");
+        result.ShouldNotContain(".p-shard-file {");
+    }
+
+    [Fact]
+    public void Process_WithArbitraryValueUtility_EmitsLiteralValue()
+    {
+        // The supported alternative to raw CSS: an arbitrary-value utility.
+        var settings = new CssFrameworkSettings
+        {
+            IncludePreflight = false,
+            Applies = ImmutableDictionary<string, string>.Empty
+                .Add(".p-shard-file", "bg-[color-mix(in_oklab,red,blue)]")
+        };
+
+        var framework = new CssFramework(settings);
+
+        var result = framework.Process("");
+        Console.WriteLine(result);
+
+        result.ShouldContain(".p-shard-file");
+        result.ShouldContain("background-color: color-mix(");
+    }
 }

--- a/tests/MonorailCss.Tests/AppliesWithPseudoElementTest.cs
+++ b/tests/MonorailCss.Tests/AppliesWithPseudoElementTest.cs
@@ -79,4 +79,56 @@ public class AppliesWithPseudoElementTest
         result.ShouldContain("position: absolute");
         result.ShouldContain("color: var(--color-blue-500)");
     }
+
+    [Fact]
+    public void Process_WithPseudoElementKeyAndVariant_ComposesWithoutDoublingPseudoElement()
+    {
+        // Regression: a pseudo-element in the Applies KEY plus a variant utility produced a
+        // doubled, malformed selector (".p-fetch-line::after::after:where(...)"). The variant
+        // fragment must be inserted before the pseudo-element, which stays terminal.
+        var settings = new CssFrameworkSettings
+        {
+            IncludePreflight = false,
+            Applies = ImmutableDictionary<string, string>.Empty
+                .Add(".p-fetch-line::after", "content-['→'] dark:text-red-300")
+        };
+
+        var framework = new CssFramework(settings);
+
+        var result = framework.Process("");
+        Console.WriteLine("Generated CSS:");
+        Console.WriteLine(result);
+
+        // Base rule keeps the pseudo-element from the key.
+        result.ShouldContain(".p-fetch-line::after");
+        result.ShouldContain("--tw-content: '→'");
+
+        // Variant rule: :where(...) inserted before the (still terminal) pseudo-element.
+        result.ShouldContain(".p-fetch-line:where(.dark, .dark *)::after");
+        result.ShouldContain("color: var(--color-red-300)");
+
+        // No doubled pseudo-element.
+        result.ShouldNotContain("::after::after");
+    }
+
+    [Fact]
+    public void Process_WithPseudoElementKeyAndPseudoClassVariant_KeepsPseudoElementLast()
+    {
+        var settings = new CssFrameworkSettings
+        {
+            IncludePreflight = false,
+            Applies = ImmutableDictionary<string, string>.Empty
+                .Add(".p-shard::before", "hover:text-red-500")
+        };
+
+        var framework = new CssFramework(settings);
+
+        var result = framework.Process("");
+        Console.WriteLine("Generated CSS:");
+        Console.WriteLine(result);
+
+        result.ShouldContain(".p-shard:hover::before");
+        result.ShouldNotContain("::before::before");
+        result.ShouldNotContain("::before:hover");
+    }
 }

--- a/tests/MonorailCss.Tests/CssFrameworkTests.cs
+++ b/tests/MonorailCss.Tests/CssFrameworkTests.cs
@@ -445,6 +445,45 @@ public partial class CssFrameworkTests
     }
 
     [Fact]
+    public void Process_ShouldGuardArbitraryMinBreakpointWithMediaQuery()
+    {
+        // Regression: min-[1100px]: previously dropped the variant and emitted opacity
+        // unguarded at every width. It must now be wrapped in a min-width media query.
+        var css = _framework.Process("min-[1100px]:opacity-35");
+
+        css.ShouldContain("@media (min-width: 1100px)");
+        css.ShouldContain(".min-\\[1100px\\]\\:opacity-35");
+
+        // The declaration must live inside the media query, not at the top level.
+        var mediaIndex = css.IndexOf("@media (min-width: 1100px)", StringComparison.Ordinal);
+        var ruleIndex = css.IndexOf(".min-\\[1100px\\]\\:opacity-35", StringComparison.Ordinal);
+        mediaIndex.ShouldBeGreaterThan(-1);
+        ruleIndex.ShouldBeGreaterThan(mediaIndex);
+    }
+
+    [Fact]
+    public void Process_ShouldGuardArbitraryMaxBreakpointWithMediaQuery()
+    {
+        var css = _framework.Process("max-[1100px]:flex");
+
+        css.ShouldContain("@media not all and (min-width: 1100px)");
+        css.ShouldContain(".max-\\[1100px\\]\\:flex");
+        css.ShouldContain("display: flex");
+    }
+
+    [Fact]
+    public void Process_ShouldResolveNamedCustomBreakpoint()
+    {
+        var customTheme = new MonorailCss.Theme.Theme().Add("--breakpoint-tablet", "1100px");
+        var customFramework = new CssFramework(new CssFrameworkSettings { Theme = customTheme });
+
+        var css = customFramework.Process("min-tablet:flex max-tablet:hidden");
+
+        css.ShouldContain("@media (min-width: 1100px)");
+        css.ShouldContain("@media not all and (min-width: 1100px)");
+    }
+
+    [Fact]
     public void Process_ShouldHandleGroupAndPeerVariants()
     {
         var css = _framework.Process("group-hover:bg-red-500 peer-focus:text-blue-700");

--- a/tests/MonorailCss.Tests/Variants/VariantIntegrationTests.cs
+++ b/tests/MonorailCss.Tests/Variants/VariantIntegrationTests.cs
@@ -189,6 +189,66 @@ public class VariantIntegrationTests
         result.Wrappers[0].Params.ShouldBe("(min-width: 640px)");
     }
 
+    [Theory]
+    [InlineData("min-[1100px]:opacity-35", "min", "[1100px]", "opacity-35")]
+    [InlineData("max-[1100px]:flex", "max", "[1100px]", "flex")]
+    [InlineData("min-tablet:flex", "min", "tablet", "flex")]
+    [InlineData("max-lg:hidden", "max", "lg", "hidden")]
+    public void ParseMinMaxBreakpointVariant_ShouldExtractFunctionalVariant(
+        string input, string expectedName, string expectedValue, string expectedUtility)
+    {
+        _parser.TryParseCandidate(input, out var candidate);
+
+        candidate.ShouldNotBeNull();
+        candidate.Variants.Length.ShouldBe(1);
+        candidate.Variants[0].Name.ShouldBe(expectedName);
+        candidate.Variants[0].Value.ShouldBe(expectedValue);
+        candidate.Variants[0].IsArbitrary.ShouldBeFalse();
+        GetUtilityName(candidate).ShouldBe(expectedUtility);
+    }
+
+    [Fact]
+    public void ApplyArbitraryMinBreakpoint_ShouldAddMinWidthMediaWrapper()
+    {
+        _parser.TryParseCandidate("min-[1100px]:opacity-35", out var candidate);
+        var result = _registry.ApplyVariants("opacity-35", candidate!.Variants);
+
+        result.Selector.Value.ShouldBe(".opacity-35");
+        result.Wrappers.Length.ShouldBe(1);
+        result.Wrappers[0].Name.ShouldBe("media");
+        result.Wrappers[0].Params.ShouldBe("(min-width: 1100px)");
+    }
+
+    [Fact]
+    public void ApplyArbitraryMaxBreakpoint_ShouldAddNotAllMinWidthMediaWrapper()
+    {
+        // Tailwind v4 emits max-* as an exclusive upper bound: not all and (min-width: X).
+        _parser.TryParseCandidate("max-[1100px]:flex", out var candidate);
+        var result = _registry.ApplyVariants("flex", candidate!.Variants);
+
+        result.Selector.Value.ShouldBe(".flex");
+        result.Wrappers.Length.ShouldBe(1);
+        result.Wrappers[0].Name.ShouldBe("media");
+        result.Wrappers[0].Params.ShouldBe("not all and (min-width: 1100px)");
+    }
+
+    [Fact]
+    public void ApplyNamedBreakpoint_ShouldResolveFromBreakpointThemeNamespace()
+    {
+        var customRegistry = new VariantRegistry();
+        var theme = new MonorailCss.Theme.Theme().Add("--breakpoint-tablet", "1100px");
+        customRegistry.RegisterBuiltInVariants(theme);
+
+        _parser.TryParseCandidate("min-tablet:flex", out var candidate);
+        candidate.ShouldNotBeNull();
+
+        var result = customRegistry.ApplyVariants("flex", candidate.Variants);
+
+        result.Wrappers.Length.ShouldBe(1);
+        result.Wrappers[0].Name.ShouldBe("media");
+        result.Wrappers[0].Params.ShouldBe("(min-width: 1100px)");
+    }
+
     [Fact]
     public void ApplyGroupVariant_ShouldCreateDescendantSelector()
     {


### PR DESCRIPTION
## Summary

Fixes three confirmed bugs, each verified against the Tailwind v4 engine for expected output. All three are covered by integration tests matching the existing test style. Full suite: **6043 passed, 0 failed**.

### 1. Arbitrary/named `min-*` / `max-*` breakpoints were silently dropped
`min-[1100px]:opacity-35` (and named `--breakpoint-*` screens) previously dropped the variant and emitted the declaration **unguarded at every width** — silent incorrectness rather than a build error. `min`/`max` are now functional variants that emit Tailwind-exact media queries:

| Input | Output |
|---|---|
| `min-[1100px]:` | `@media (min-width: 1100px)` |
| `max-[1100px]:` | `@media not all and (min-width: 1100px)` |

Named values (`min-tablet:`, `max-lg:`) resolve from the `--breakpoint-*` theme namespace.

### 2. Pseudo-element in an `Applies` key + a variant produced a malformed selector
`Applies[".p-fetch-line::after"] = "content-['→'] dark:text-..."` emitted `.p-fetch-line::after::after:where(.dark, .dark *)` (doubled `::after`, `:where()` after the pseudo-element). The trailing pseudo-element is now split off, variants compose against the base, and the pseudo-element is re-appended last:

```
.p-fetch-line:where(.dark, .dark *)::after
```

### 3. Raw CSS as an `Applies` value — doc/impl mismatch
Only an XML-doc comment claimed "raw CSS" support. Tailwind's `@apply` is utilities-only and errors on raw CSS. Corrected the doc to utilities-only; the supported path for literal values is arbitrary-value utilities (`bg-[color-mix(...)]`).

## Changes
- `VariantTokenizer.cs` — tokenize `min-`/`max-` as functional variants (brackets preserved); drop bare `min`/`max` from `IsBreakpointVariant`.
- `BreakpointRangeVariant.cs` (new) — resolves arbitrary lengths and `--breakpoint-*` named values; Tailwind-exact media output.
- `VariantRegistry.cs` — register `min`/`max`.
- `ApplyProcessor.cs` — `SplitTrailingPseudoElement` + re-append pseudo-element last.
- `CssFrameworkSettings.cs` — corrected `Applies` doc.
- Tests: `VariantIntegrationTests`, `CssFrameworkTests`, `AppliesWithPseudoElementTest`, `AppliesIntegrationTest`.

## Known limitation
Bare custom static screens (`tablet:` from `--breakpoint-tablet`) still don't generate — that needs dynamic registration of named screen variants. Use `min-tablet:` / `max-tablet:` for custom breakpoints in the meantime. The general silent-drop of *other* unknown variants (typos) is intentionally unchanged in this PR.

## Verification
```
dotnet run --project tests/MonorailCss.Interactive -- "min-[1100px]:opacity-35" "max-[1100px]:flex"
dotnet test tests/MonorailCss.Tests/MonorailCss.Tests.csproj   # 6043 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
