### PR TITLE
ci: run build + tests on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,13 @@ on:
     - 'readme.md'
     - 'src/TryMonorail/**'
     branches: [main]
+  pull_request:
+    paths-ignore:
+    - 'changelog.md'
+    - 'license.md'
+    - 'readme.md'
+    - 'src/TryMonorail/**'
+    branches: [main]
 
 jobs:
   build:
@@ -23,7 +30,7 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         global-json-file: global.json
-    - name: Build, Test (Debug & Release), Publish (main only)
+    - name: Build, Test (Debug & Release); publish on main/tag
       shell: bash
       run: |
         dotnet tool install --global dotnet-releaser


### PR DESCRIPTION
Add a pull_request trigger (targeting main, same paths-ignore) to the
ci workflow so PRs get build + test validation before merge.

dotnet-releaser run auto-detects the PR event and performs a full build
+ tests without publishing, so no NuGet/GitHub release happens on PRs and
no secrets are required (fork PRs build fine too).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
