### PR TITLE
feat(discovery): scan package static web assets for utility classes

### DIFF
--- a/docs/MonorailCss.Docs/Content/basics/aspnet-integration.md
+++ b/docs/MonorailCss.Docs/Content/basics/aspnet-integration.md
@@ -70,7 +70,7 @@ The default `OutputFile` is `wwwroot/css/%(Filename).css`, so `wwwroot/app.css` 
 <link rel="stylesheet" href="/css/app.css" />
 ```
 
-The task runs during `dotnet build`, scans the same source files and DLLs Discovery does, and writes the file before content packaging. Rebuilds are incremental: unchanged inputs don't get rescanned. The `Clean` target removes the generated file.
+The task runs during `dotnet build`, scans the same source files, DLLs, and package static web assets Discovery does, and writes the file before content packaging. Rebuilds are incremental: unchanged inputs don't get rescanned. The `Clean` target removes the generated file.
 
 > **Note:** `dotnet watch` does not re-trigger MSBuild targets. Build.Tasks alone won't keep your CSS fresh during a watch session &mdash; see the [hybrid section](#hybrid-build-time--dotnet-watch) for how to combine it with Discovery.
 
@@ -102,6 +102,7 @@ The placeholders inside `@source` paths (`$(Configuration)`, `$(TargetFramework)
 |---|---|
 | `<MonorailCssEnabled>` | On/off; default `true`. Gate on `'$(Configuration)' == 'Release'` if you're combining with Discovery. |
 | `<MonorailCssExcludeAssemblies>` | Semicolon-delimited assembly names to skip (e.g. `FluentValidation;BadIdeas.Icons.FontAwesome`). |
+| `<MonorailCssScanStaticWebAssets>` | On/off; default `true`. Scans `.js`/`.mjs` shipped by referenced packages as static web assets (e.g. `_content/Pennington.UI/scripts.js`). Razor/Web SDK projects only. |
 | `<MonorailCss>` `Include` | The entry CSS file. Multiple items produce multiple outputs. |
 | `<MonorailCss>` `OutputFile` metadata | Override the default `wwwroot/css/%(Filename).css`. |
 
@@ -140,7 +141,7 @@ Point your layout at the served stylesheet:
 <link rel="stylesheet" href="/_monorail/app.css" />
 ```
 
-With no configuration `AddMonorailCss` auto-detects `wwwroot/app.css`, scans every non-BCL referenced assembly for class strings, watches your source tree for changes in Development, and serves the result at `/_monorail/app.css`. Edit a class in a `.razor` file under `dotnet watch` and the browser sees the new CSS on the next HEAD poll.
+With no configuration `AddMonorailCss` auto-detects `wwwroot/app.css`, scans every non-BCL referenced assembly for class strings, scans JavaScript shipped by component packages as static web assets, watches your source tree for changes in Development, and serves the result at `/_monorail/app.css`. Edit a class in a `.razor` file under `dotnet watch` and the browser sees the new CSS on the next HEAD poll.
 
 ### Configuration
 
@@ -159,6 +160,7 @@ The options you'll actually reach for:
 
 - **`ExcludeAssemblies`** &mdash; skip libraries whose IL strings would inflate the candidate set without contributing real utilities. Icon packs that bake thousands of class-shaped tokens into metadata are the usual culprits. MonorailCSS itself and BCL assemblies (`System.*`, `Microsoft.*`) are excluded automatically.
 - **`ExtraSafelist`** &mdash; force-include classes static scanning can't reconstruct, e.g. anything built at runtime via `$"bg-{color}-500"`.
+- **`ScanStaticWebAssets`** &mdash; on by default; reads classes out of JavaScript that referenced packages/RCLs ship under `_content/<Package>/`. Those files live in the NuGet cache &mdash; outside your source tree and the assembly IL &mdash; so nothing else reaches them; a component whose modal markup is built in `scripts.js` needs this. Narrow what's read with `StaticWebAssetExtensions` (default `.js`, `.mjs`), or suppress a package's assets by adding it to `ExcludeAssemblies`.
 - **`SourceCssPath`** &mdash; path to your entry CSS file. Auto-detected as `wwwroot/app.css` when unset.
 - **`CssEndpoint`** &mdash; the URL the middleware serves CSS at, default `/_monorail/app.css`. Change it to share a URL with a build-time static file (see hybrid below).
 - **`Framework`** &mdash; supply a pre-configured `CssFramework` when you need to seed prose configuration or register utilities programmatically. See [configuration](xref:configuration). The CSS file processing layers on top.

--- a/src/MonorailCss.Build.Tasks/CLAUDE.md
+++ b/src/MonorailCss.Build.Tasks/CLAUDE.md
@@ -70,6 +70,10 @@ Uses regex patterns to extract class names from various frameworks:
 
 **DllScanner.cs**: Scans .NET assemblies (DLLs) for utility class strings embedded in string literals using PE metadata reader. Extracts string values from the #Strings heap in the metadata tables.
 
+### Static Web Asset Scanning
+
+Component packages (RCLs) ship JS under `_content/<Package>/` (e.g. `_content/Pennington.UI/scripts.js`) that builds markup at runtime. Those files live in the NuGet cache, never enter IL, and sit outside the project tree, so neither the content sweep nor the DLL scan reaches them. The `targets` file resolves them via `ResolveBuildStaticWebAssets` (which populates `@(StaticWebAsset)` with own + project + package assets), filters to `.js`/`.mjs` (the `AssetRole != Alternative` filter drops compressed `.gz`/`.br` siblings), and forwards the physical paths to `ProcessCssTask.StaticWebAssets`. They flow through the same `SourceFileScanner` as content files (generic-tokenizer strategy for `.js`). The dependency is gated on `'$(UsingMicrosoftNETSdkRazor)' == 'true'` so plain library/console consumers build untouched; set `MonorailCssScanStaticWebAssets=false` to opt out. Assets owned by a `MonorailCssExcludeAssembly` are skipped by their `SourceId` metadata, mirroring the runtime's `_content/<Package>` exclusion. Mirrors `MonorailDiscoveryOptions.ScanStaticWebAssets` on the runtime side.
+
 ## Usage
 
 Typically consumed via NuGet package. The task is automatically invoked during build when configured in the project file:

--- a/src/MonorailCss.Build.Tasks/ProcessCssTask.cs
+++ b/src/MonorailCss.Build.Tasks/ProcessCssTask.cs
@@ -90,6 +90,18 @@ public class ProcessCssTask : Microsoft.Build.Utilities.Task
     public ITaskItem[]? ExcludeAssemblies { get; set; }
 
     /// <summary>
+    /// Gets or sets the static web asset files to scan for utility classes, populated from
+    /// <c>@(StaticWebAsset)</c> by the targets file (already filtered to scannable extensions).
+    /// These are component-/RCL-shipped assets — e.g. <c>_content/Pennington.UI/scripts.js</c>
+    /// — that live in the NuGet cache rather than the project tree, so the ordinary
+    /// content-file sweep never reaches them. Each item's <c>ItemSpec</c> is the physical file
+    /// path; the <c>SourceId</c> metadata (the owning package/assembly) is honored against
+    /// <see cref="ExcludeAssemblies"/>. Mirrors
+    /// <c>MonorailDiscoveryOptions.ScanStaticWebAssets</c> on the runtime side.
+    /// </summary>
+    public ITaskItem[]? StaticWebAssets { get; set; }
+
+    /// <summary>
     /// Gets or sets the build configuration (e.g., "Debug", "Release"). Used to resolve
     /// <c>$(Configuration)</c> placeholders in <c>@source</c> paths.
     /// </summary>
@@ -165,9 +177,10 @@ public class ProcessCssTask : Microsoft.Build.Utilities.Task
             // pre-parse for the directive set only.
             var sourceConfig = ParseSourceConfiguration();
 
-            var sourceFiles = ResolveSourceFiles(rootDir, sourceConfig);
-            var assemblyFiles = ResolveAssemblyFiles(rootDir, sourceConfig);
             var excludes = BuildExcludeSet();
+            var sourceFiles = ResolveSourceFiles(rootDir, sourceConfig);
+            AddStaticWebAssetFiles(sourceFiles, excludes);
+            var assemblyFiles = ResolveAssemblyFiles(rootDir, sourceConfig);
             var safelist = sourceConfig.InlineSources.SelectMany(s => s.ExpandedUtilities).ToList();
 
             Log.LogMessage(
@@ -299,6 +312,48 @@ public class ProcessCssTask : Microsoft.Build.Utilities.Task
         }
 
         return set;
+    }
+
+    /// <summary>
+    /// Unions package-shipped static web asset files (from <see cref="StaticWebAssets"/>) into
+    /// the source-file scan list. Assets owned by an excluded package (by <c>SourceId</c>
+    /// metadata) are skipped, mirroring the runtime's <c>_content/&lt;Package&gt;</c> exclusion.
+    /// </summary>
+    private void AddStaticWebAssetFiles(List<string> sourceFiles, HashSet<string> excludes)
+    {
+        if (StaticWebAssets is null || StaticWebAssets.Length == 0)
+        {
+            return;
+        }
+
+        var seen = new HashSet<string>(sourceFiles, StringComparer.OrdinalIgnoreCase);
+        var added = 0;
+        foreach (var item in StaticWebAssets)
+        {
+            var path = item.ItemSpec?.Trim();
+            if (string.IsNullOrEmpty(path))
+            {
+                continue;
+            }
+
+            var sourceId = item.GetMetadata("SourceId");
+            if (!string.IsNullOrEmpty(sourceId) && excludes.Contains(sourceId))
+            {
+                continue;
+            }
+
+            var full = Path.GetFullPath(path);
+            if (seen.Add(full) && _fileSystem.File.Exists(full))
+            {
+                sourceFiles.Add(full);
+                added++;
+            }
+        }
+
+        if (added > 0)
+        {
+            Log.LogMessage(MessageImportance.Low, $"MonorailCss: scanning {added} static web asset file(s)");
+        }
     }
 
     /// <summary>

--- a/src/MonorailCss.Build.Tasks/build/MonorailCss.Build.Tasks.targets
+++ b/src/MonorailCss.Build.Tasks/build/MonorailCss.Build.Tasks.targets
@@ -28,6 +28,20 @@
     </MonorailCssExcludeAssembly>
   </ItemDefinitionGroup>
 
+  <!-- Static web asset scanning. Component packages (RCLs) ship JS under _content/<Package>/
+       that builds markup at runtime; those files live in the NuGet cache, never enter IL, and
+       sit outside the project tree, so the content sweep and the IL scan both miss them.
+       ResolveBuildStaticWebAssets populates @(StaticWebAsset) with the fully-resolved set
+       (own + project + package assets). That target only exists in Razor/Web SDK projects, so
+       the dependency is gated on UsingMicrosoftNETSdkRazor — plain library/console consumers
+       (no static web assets) keep building untouched. Set MonorailCssScanStaticWebAssets=false
+       to opt out entirely. Mirrors MonorailDiscoveryOptions.ScanStaticWebAssets at runtime. -->
+  <PropertyGroup>
+    <MonorailCssScanStaticWebAssets Condition="'$(MonorailCssScanStaticWebAssets)' == ''">true</MonorailCssScanStaticWebAssets>
+    <_MonorailCssProcessDependsOn>ResolveProjectReferences;ResolveAssemblyReferences</_MonorailCssProcessDependsOn>
+    <_MonorailCssProcessDependsOn Condition="'$(MonorailCssScanStaticWebAssets)' == 'true' and '$(UsingMicrosoftNETSdkRazor)' == 'true'">$(_MonorailCssProcessDependsOn);ResolveBuildStaticWebAssets</_MonorailCssProcessDependsOn>
+  </PropertyGroup>
+
   <!-- Process each MonorailCss file.
        BeforeTargets="CoreCompile" runs after ResolveAssemblyReferences populates
        @(ReferencePath) with absolute paths to every project + package + framework reference
@@ -38,9 +52,9 @@
        resolves. -->
   <Target Name="ProcessMonorailCss"
           BeforeTargets="CoreCompile"
-          DependsOnTargets="ResolveProjectReferences;ResolveAssemblyReferences"
+          DependsOnTargets="$(_MonorailCssProcessDependsOn)"
           Condition="'$(MonorailCssEnabled)' == 'true' and '@(MonorailCss)' != ''"
-          Inputs="@(MonorailCss);@(Content);@(Compile);@(EmbeddedResource);@(ReferencePath)"
+          Inputs="@(MonorailCss);@(Content);@(Compile);@(EmbeddedResource);@(ReferencePath);@(StaticWebAsset)"
           Outputs="@(MonorailCss->'%(OutputFile)')">
 
     <ItemGroup>
@@ -66,11 +80,22 @@
       <_MonorailCssExcludeAssembly Include="@(MonorailCssExcludeAssembly)" />
     </ItemGroup>
 
+    <!-- Forward component-package JS / ES modules shipped as static web assets. The extension
+         filter keeps only .js/.mjs — which also drops the compressed .gz/.br siblings, whose
+         Identity ends in .gz/.br — and the AssetRole filter is belt-and-suspenders against
+         those compressed "Alternative" entries. %(Extension) reads off each asset's physical
+         Identity path. -->
+    <ItemGroup Condition="'$(MonorailCssScanStaticWebAssets)' == 'true'">
+      <_MonorailCssStaticWebAsset Include="@(StaticWebAsset)"
+                                  Condition="('%(Extension)' == '.js' or '%(Extension)' == '.mjs') and '%(StaticWebAsset.AssetRole)' != 'Alternative'" />
+    </ItemGroup>
+
     <ProcessCssTask
       InputFile="%(MonorailCss.Identity)"
       OutputFile="%(MonorailCss.OutputFile)"
       ReferencePaths="@(ReferencePath)"
       ExcludeAssemblies="@(_MonorailCssExcludeAssembly)"
+      StaticWebAssets="@(_MonorailCssStaticWebAsset)"
       Configuration="$(Configuration)"
       TargetFramework="$(TargetFramework)"
       RuntimeIdentifier="$(RuntimeIdentifier)"

--- a/src/MonorailCss.Discovery/ClassDiscoveryService.cs
+++ b/src/MonorailCss.Discovery/ClassDiscoveryService.cs
@@ -33,6 +33,7 @@ internal sealed partial class ClassDiscoveryService : IHostedService, IClassRegi
     private int _regenerateCount;
     private int _hotReloadCount;
     private bool _started;
+    private List<string>? _staticWebAssetFiles;
 
     public ClassDiscoveryService(
         IOptions<MonorailDiscoveryOptions> options,
@@ -447,7 +448,7 @@ internal sealed partial class ClassDiscoveryService : IHostedService, IClassRegi
             SourceCssPath = _options.SourceCssPath,
             BaseFramework = _options.Framework,
             Assemblies = AppDomain.CurrentDomain.GetAssemblies(),
-            SourceFiles = (skipSourceFileScan || hasChangedFiles) ? Array.Empty<string>() : EnumerateWatchedSourceFiles(),
+            SourceFiles = (skipSourceFileScan || hasChangedFiles) ? Array.Empty<string>() : EnumerateScanSourceFiles(),
             ExtraSafelist = _options.ExtraSafelist,
             ExcludeAssemblies = _options.ExcludeAssemblies,
             SkipSourceFileScan = skipSourceFileScan,
@@ -498,6 +499,13 @@ internal sealed partial class ClassDiscoveryService : IHostedService, IClassRegi
         ".venv", "venv", "__pycache__",
     };
 
+    private List<string> EnumerateScanSourceFiles()
+    {
+        var files = EnumerateWatchedSourceFiles();
+        files.AddRange(GetStaticWebAssetFiles());
+        return files;
+    }
+
     private List<string> EnumerateWatchedSourceFiles()
     {
         var files = new List<string>();
@@ -512,6 +520,104 @@ internal sealed partial class ClassDiscoveryService : IHostedService, IClassRegi
         }
 
         return files;
+    }
+
+    /// <summary>
+    /// Resolves the physical paths of package-shipped static web assets (e.g.
+    /// <c>_content/Pennington.UI/scripts.js</c>) eligible for scanning. The result is computed
+    /// once and cached for the process: the entry assembly's runtime manifest is fixed at
+    /// build time, and the resolved files (NuGet-cache paths) are immutable, so re-reading the
+    /// manifest on every regeneration would be wasted I/O. The files flow through the same
+    /// <c>SourceFileScanner</c> as ordinary source files, so they inherit its per-file mtime
+    /// and incremental token caches.
+    /// </summary>
+    private IReadOnlyList<string> GetStaticWebAssetFiles()
+    {
+        return _staticWebAssetFiles ??= ResolveStaticWebAssetFiles();
+    }
+
+    private List<string> ResolveStaticWebAssetFiles()
+    {
+        var result = new List<string>();
+        if (!_options.ScanStaticWebAssets)
+        {
+            return result;
+        }
+
+        var entry = Assembly.GetEntryAssembly();
+        if (entry is null)
+        {
+            return result;
+        }
+
+        var manifestPath = StaticWebAssetManifest.GetManifestPath(entry);
+        if (manifestPath is null || !File.Exists(manifestPath))
+        {
+            return result;
+        }
+
+        string json;
+        try
+        {
+            json = File.ReadAllText(manifestPath);
+        }
+        catch (IOException)
+        {
+            return result;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return result;
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var asset in StaticWebAssetManifest.Resolve(json))
+        {
+            var ext = Path.GetExtension(asset.PhysicalPath);
+            if (!_options.StaticWebAssetExtensions.Contains(ext))
+            {
+                continue;
+            }
+
+            if (IsExcludedStaticWebAssetPackage(asset.UrlPath))
+            {
+                continue;
+            }
+
+            if (seen.Add(asset.PhysicalPath) && File.Exists(asset.PhysicalPath))
+            {
+                result.Add(asset.PhysicalPath);
+            }
+        }
+
+        LogMonorailcssDiscoveryStaticWebAssetsScannedCountManifest(result.Count, manifestPath);
+        return result;
+    }
+
+    /// <summary>
+    /// Maps a served URL path back to its owning package and tests it against
+    /// <see cref="MonorailDiscoveryOptions.ExcludeAssemblies"/>. Served paths look like
+    /// <c>_content/&lt;Package&gt;/path/to.js</c>, and an RCL's <c>_content</c> base segment is
+    /// its assembly name, so excluding the assembly also suppresses its shipped assets. Assets
+    /// outside <c>_content</c> (the app's own) are never excluded.
+    /// </summary>
+    private bool IsExcludedStaticWebAssetPackage(string urlPath)
+    {
+        const string prefix = "_content/";
+        if (!urlPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var rest = urlPath.AsSpan(prefix.Length);
+        var slash = rest.IndexOf('/');
+        if (slash <= 0)
+        {
+            return false;
+        }
+
+        var package = rest.Slice(0, slash).ToString();
+        return _options.ExcludeAssemblies.Contains(package);
     }
 
     private static void EnumerateSourceFilesInto(string root, List<string> output)
@@ -664,6 +770,9 @@ internal sealed partial class ClassDiscoveryService : IHostedService, IClassRegi
 
     [LoggerMessage(LogLevel.Debug, "MonorailCss discovery startup: {ClassCount} classes in {ElapsedMs} ms — ETag {Etag}")]
     partial void LogMonorailcssDiscoveryStartupClassCloutElapsedMsEtag(int classCount, long elapsedMs, string etag);
+
+    [LoggerMessage(LogLevel.Debug, "MonorailCss discovery: scanned {Count} static web asset file(s) from {ManifestPath}")]
+    partial void LogMonorailcssDiscoveryStaticWebAssetsScannedCountManifest(int count, string manifestPath);
 }
 
 /// <summary>

--- a/src/MonorailCss.Discovery/MonorailDiscoveryOptions.cs
+++ b/src/MonorailCss.Discovery/MonorailDiscoveryOptions.cs
@@ -79,6 +79,30 @@ public sealed class MonorailDiscoveryOptions
     public string? WriteToFile { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether discovery scans assets shipped by referenced
+    /// packages / Razor Class Libraries as static web assets (the
+    /// <c>_content/&lt;Package&gt;/…</c> set) for utility classes. These files — JavaScript that
+    /// builds markup at runtime, most commonly — live in the NuGet package cache, never enter
+    /// the assembly's IL, and are not inside any watched source directory, so neither the IL
+    /// scan nor the source-file scan can see them. When enabled (the default), the entry
+    /// assembly's <c>{name}.staticwebassets.runtime.json</c> manifest is read once at startup,
+    /// every enumerated asset whose extension is in <see cref="StaticWebAssetExtensions"/> is
+    /// resolved to its physical path, and those files are scanned through the same tokenizer
+    /// the source-file scan uses. Packages listed in <see cref="ExcludeAssemblies"/> are
+    /// skipped here too (matched against the <c>_content/&lt;Package&gt;</c> segment).
+    /// </summary>
+    public bool ScanStaticWebAssets { get; set; } = true;
+
+    /// <summary>
+    /// Gets the file extensions (each including the leading dot) eligible for static-web-asset
+    /// scanning when <see cref="ScanStaticWebAssets"/> is enabled. Defaults to <c>.js</c> and
+    /// <c>.mjs</c>. Kept deliberately narrow — an RCL's <c>_content</c> also carries CSS,
+    /// images, fonts, and source maps that have no utility classes worth extracting.
+    /// </summary>
+    public HashSet<string> StaticWebAssetExtensions { get; } =
+        new(StringComparer.OrdinalIgnoreCase) { ".js", ".mjs" };
+
+    /// <summary>
     /// Gets a list of source directories to watch for utility-class changes during development.
     /// When non-empty, a <see cref="FileSystemWatcher"/> watches each directory recursively for
     /// <c>.razor</c>, <c>.cshtml</c>, and <c>.cs</c> changes, then re-extracts class strings

--- a/src/MonorailCss.Discovery/StaticWebAssetManifest.cs
+++ b/src/MonorailCss.Discovery/StaticWebAssetManifest.cs
@@ -1,0 +1,168 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MonorailCss.Discovery;
+
+/// <summary>
+/// Resolves an ASP.NET Core static web assets <em>runtime</em> manifest
+/// (<c>{EntryAssembly}.staticwebassets.runtime.json</c>) into physical on-disk file paths.
+/// <para>
+/// Component packages (Razor Class Libraries) ship assets — JavaScript especially — under
+/// their <c>wwwroot</c>, served at <c>_content/&lt;Package&gt;/…</c>. Those files live in the
+/// NuGet package cache, never enter the assembly's IL, and are not inside any directory the
+/// source-file scan walks. Discovery therefore can't reach utility classes baked into, say,
+/// <c>_content/Pennington.UI/scripts.js</c> through either the IL scan or the source scan.
+/// The runtime manifest is the one artifact that maps each served asset to its physical
+/// location, so reading it closes that gap.
+/// </para>
+/// <para>
+/// Only explicitly enumerated assets are resolved. Pattern-based content roots (the app's own
+/// globbed <c>wwwroot</c>) are intentionally not expanded — every package/RCL <c>_content</c>
+/// asset is enumerated, and the app's own assets live under the content root the source-file
+/// scan already covers.
+/// </para>
+/// </summary>
+public static class StaticWebAssetManifest
+{
+    /// <summary>
+    /// One resolved asset: the URL path it is served at (e.g.
+    /// <c>_content/Pennington.UI/scripts.js</c>) and its physical file path on disk.
+    /// </summary>
+    /// <param name="UrlPath">The served path, built from the manifest trie keys.</param>
+    /// <param name="PhysicalPath">The absolute on-disk path
+    /// (<c>ContentRoots[index]</c> + <c>SubPath</c>).</param>
+    public readonly record struct ResolvedAsset(string UrlPath, string PhysicalPath);
+
+    /// <summary>
+    /// Returns the conventional runtime-manifest path for <paramref name="assembly"/>:
+    /// <c>{assemblyLocation-without-extension}.staticwebassets.runtime.json</c> next to the
+    /// assembly. Returns <see langword="null"/> when the assembly has no on-disk location
+    /// (single-file publish, in-memory, etc.), where no manifest can be found.
+    /// </summary>
+    /// <param name="assembly">The assembly whose manifest to locate — typically the entry assembly.</param>
+    /// <returns>The expected manifest path, or <see langword="null"/> when it can't be derived.</returns>
+    public static string? GetManifestPath(Assembly assembly)
+    {
+        var location = assembly.Location;
+        if (string.IsNullOrEmpty(location))
+        {
+            return null;
+        }
+
+        var dir = Path.GetDirectoryName(location);
+        var name = Path.GetFileNameWithoutExtension(location);
+        if (string.IsNullOrEmpty(dir) || string.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+
+        return Path.Combine(dir, name + ".staticwebassets.runtime.json");
+    }
+
+    /// <summary>
+    /// Parses a static web assets runtime manifest and resolves every enumerated asset to its
+    /// physical path. Returns an empty list on any parse error or when the manifest is
+    /// structurally empty.
+    /// </summary>
+    /// <param name="manifestJson">The raw manifest JSON.</param>
+    /// <returns>Every enumerated asset, paired with its resolved physical path.</returns>
+    public static IReadOnlyList<ResolvedAsset> Resolve(string manifestJson)
+    {
+        if (string.IsNullOrWhiteSpace(manifestJson))
+        {
+            return [];
+        }
+
+        StaticWebAssetRuntimeManifest? manifest;
+        try
+        {
+            manifest = JsonSerializer.Deserialize(
+                manifestJson,
+                StaticWebAssetManifestJsonContext.Default.StaticWebAssetRuntimeManifest);
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+
+        if (manifest?.Root is null || manifest.ContentRoots is null || manifest.ContentRoots.Length == 0)
+        {
+            return [];
+        }
+
+        var roots = manifest.ContentRoots;
+        var result = new List<ResolvedAsset>();
+
+        // Iterative DFS over the trie. Each node's accumulated key path is the served URL; a
+        // node carrying an Asset is a leaf we can resolve to a physical file.
+        var stack = new Stack<(string Path, StaticWebAssetNode Node)>();
+        stack.Push((string.Empty, manifest.Root));
+
+        while (stack.Count > 0)
+        {
+            var (prefix, node) = stack.Pop();
+
+            if (node.Asset is { } asset
+                && asset.ContentRootIndex >= 0
+                && asset.ContentRootIndex < roots.Length
+                && !string.IsNullOrEmpty(roots[asset.ContentRootIndex]))
+            {
+                var physical = Path.Combine(roots[asset.ContentRootIndex]!, asset.SubPath ?? string.Empty);
+                result.Add(new ResolvedAsset(prefix, physical));
+            }
+
+            if (node.Children is null)
+            {
+                continue;
+            }
+
+            foreach (var (segment, child) in node.Children)
+            {
+                if (child is null)
+                {
+                    continue;
+                }
+
+                var childPath = prefix.Length == 0 ? segment : prefix + "/" + segment;
+                stack.Push((childPath, child));
+            }
+        }
+
+        return result;
+    }
+}
+
+/// <summary>Root of the static web assets runtime manifest: the content-root table plus the asset trie.</summary>
+internal sealed class StaticWebAssetRuntimeManifest
+{
+    /// <summary>Gets or sets the base directories assets resolve against, indexed by <see cref="StaticWebAssetEntry.ContentRootIndex"/>.</summary>
+    public string?[]? ContentRoots { get; set; }
+
+    /// <summary>Gets or sets the root trie node whose descendants enumerate the served assets.</summary>
+    public StaticWebAssetNode? Root { get; set; }
+}
+
+/// <summary>One trie node: optional child segments and an optional asset payload when the node is a leaf.</summary>
+internal sealed class StaticWebAssetNode
+{
+    /// <summary>Gets or sets the child segments keyed by URL path segment.</summary>
+    public Dictionary<string, StaticWebAssetNode>? Children { get; set; }
+
+    /// <summary>Gets or sets the asset this node resolves to, when it is a leaf.</summary>
+    public StaticWebAssetEntry? Asset { get; set; }
+}
+
+/// <summary>The physical-location payload of a leaf trie node.</summary>
+internal sealed class StaticWebAssetEntry
+{
+    /// <summary>Gets or sets the index into <see cref="StaticWebAssetRuntimeManifest.ContentRoots"/>.</summary>
+    public int ContentRootIndex { get; set; }
+
+    /// <summary>Gets or sets the path under the content root that locates the file.</summary>
+    public string? SubPath { get; set; }
+}
+
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(StaticWebAssetRuntimeManifest))]
+internal sealed partial class StaticWebAssetManifestJsonContext : JsonSerializerContext;

--- a/tests/MonorailCss.Build.Tasks.Tests/ProcessCssTaskTests.cs
+++ b/tests/MonorailCss.Build.Tasks.Tests/ProcessCssTaskTests.cs
@@ -115,6 +115,53 @@ public class ProcessCssTaskTests
     }
 
     [Fact]
+    public void Execute_ScansStaticWebAssetJavaScript()
+    {
+        using var ws = new TestWorkspace();
+
+        var inputPath = ws.WriteFile("app.css", """@import "tailwindcss";""");
+
+        // The .js asset lives under a name the default content sweep ignores (it only globs
+        // .html/.razor/etc.), and no markup references w-3/h-3 — so if those classes appear in
+        // the output, the static-web-asset path is the only thing that could have surfaced them.
+        var jsPath = ws.WriteFile("_pkg/scripts.js", "el.classList.add('w-3', 'h-3');");
+        var outputPath = ws.PathFor("wwwroot/app.css");
+
+        var task = ws.CreateTask(inputPath, outputPath);
+        task.StaticWebAssets = [new TaskItem(jsPath)];
+
+        task.Execute().ShouldBeTrue();
+
+        var output = File.ReadAllText(outputPath);
+        output.ShouldContain(".w-3");
+        output.ShouldContain(".h-3");
+    }
+
+    [Fact]
+    public void Execute_SkipsStaticWebAssets_FromExcludedPackage()
+    {
+        using var ws = new TestWorkspace();
+
+        var inputPath = ws.WriteFile("app.css", """@import "tailwindcss";""");
+        var jsPath = ws.WriteFile("_pkg/scripts.js", "el.classList.add('w-3', 'h-3');");
+        var outputPath = ws.PathFor("wwwroot/app.css");
+
+        var asset = new TaskItem(jsPath);
+        asset.SetMetadata("SourceId", "Excluded.Pkg");
+
+        var task = ws.CreateTask(inputPath, outputPath);
+        task.StaticWebAssets = [asset];
+        task.ExcludeAssemblies = [new TaskItem("Excluded.Pkg")];
+
+        task.Execute().ShouldBeTrue();
+
+        // The owning package is excluded, so its JS must not contribute classes.
+        var output = File.ReadAllText(outputPath);
+        output.ShouldNotContain(".w-3");
+        output.ShouldNotContain(".h-3");
+    }
+
+    [Fact]
     public void Execute_WithCustomUtilityMixingDeclarationsAndNestedSelectors_GeneratesOutput()
     {
         using var ws = new TestWorkspace();

--- a/tests/MonorailCss.Tests/Discovery/DiscoveryTokenizationTests.cs
+++ b/tests/MonorailCss.Tests/Discovery/DiscoveryTokenizationTests.cs
@@ -33,6 +33,48 @@ public class DiscoveryTokenizationTests
     }
 
     [Fact]
+    public void SourceFileScanner_Should_Extract_Classes_From_JavaScript()
+    {
+        // A .js file falls through to the generic CandidateLexer strategy, so utility classes
+        // survive regardless of how the script applies them — className assignment, classList
+        // calls, or a bare space-delimited string literal (the shape Pennington.UI's
+        // scripts.js uses to build its modal: 'w-3 h-3').
+        var framework = new CssFramework();
+        var scanner = new SourceFileScanner(new ValidationCache(framework));
+
+        var path = WriteTempFile(
+            ".js",
+            """
+            export function modal() {
+              const el = document.createElement('div');
+              el.className = 'fixed inset-0 flex items-center justify-center';
+              const icon = document.createElement('span');
+              icon.classList.add('w-3', 'h-3');
+              el.innerHTML = `<button class="rounded-md px-4 py-2">close</button>`;
+              return el;
+            }
+            """);
+
+        try
+        {
+            var bucket = new HashSet<string>(StringComparer.Ordinal);
+            scanner.ScanFile(path, bucket);
+
+            bucket.ShouldContain("w-3");
+            bucket.ShouldContain("h-3");
+            bucket.ShouldContain("fixed");
+            bucket.ShouldContain("inset-0");
+            bucket.ShouldContain("items-center");
+            bucket.ShouldContain("rounded-md");
+            bucket.ShouldContain("px-4");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void CandidateLexer_Should_Emit_DigitLeading_Tokens()
     {
         var tokens = new HashSet<string>(StringComparer.Ordinal);

--- a/tests/MonorailCss.Tests/Discovery/StaticWebAssetManifestTests.cs
+++ b/tests/MonorailCss.Tests/Discovery/StaticWebAssetManifestTests.cs
@@ -1,0 +1,138 @@
+using MonorailCss.Discovery;
+using Shouldly;
+
+namespace MonorailCss.Tests.Discovery;
+
+public class StaticWebAssetManifestTests
+{
+    // Mirrors the real {App}.staticwebassets.runtime.json shape: a ContentRoots table plus a
+    // trie whose leaves carry {ContentRootIndex, SubPath}. Forward-slash roots keep the JSON
+    // free of backslash escaping and round-trip identically through Path.Combine on both OSes.
+    private const string SampleManifest =
+        """
+        {
+          "ContentRoots": [
+            "/nuget/aspnetcore/_framework/",
+            "/proj/obj/compressed/",
+            "/nuget/pennington.ui/0.1.0/staticwebassets/"
+          ],
+          "Root": {
+            "Children": {
+              "_framework": {
+                "Children": {
+                  "blazor.web.js": {
+                    "Children": null,
+                    "Asset": { "ContentRootIndex": 0, "SubPath": "blazor.web.js" },
+                    "Patterns": null
+                  }
+                },
+                "Asset": null,
+                "Patterns": null
+              },
+              "_content": {
+                "Children": {
+                  "Pennington.UI": {
+                    "Children": {
+                      "scripts.js": {
+                        "Children": null,
+                        "Asset": { "ContentRootIndex": 2, "SubPath": "scripts.js" },
+                        "Patterns": null
+                      },
+                      "scripts.js.gz": {
+                        "Children": null,
+                        "Asset": { "ContentRootIndex": 1, "SubPath": "aaov-{0}-7cod.gz" },
+                        "Patterns": null
+                      }
+                    },
+                    "Asset": null,
+                    "Patterns": null
+                  }
+                },
+                "Asset": null,
+                "Patterns": null
+              }
+            },
+            "Asset": null,
+            "Patterns": null
+          }
+        }
+        """;
+
+    [Fact]
+    public void Resolve_Maps_Content_Asset_To_Physical_Nuget_Path()
+    {
+        var byUrl = StaticWebAssetManifest.Resolve(SampleManifest)
+            .ToDictionary(a => a.UrlPath, a => a.PhysicalPath);
+
+        byUrl.ShouldContainKey("_content/Pennington.UI/scripts.js");
+        byUrl["_content/Pennington.UI/scripts.js"]
+            .ShouldBe(Path.Combine("/nuget/pennington.ui/0.1.0/staticwebassets/", "scripts.js"));
+    }
+
+    [Fact]
+    public void Resolve_Builds_Url_Path_From_Trie_Keys()
+    {
+        var urls = StaticWebAssetManifest.Resolve(SampleManifest).Select(a => a.UrlPath).ToList();
+
+        urls.ShouldContain("_framework/blazor.web.js");
+        urls.ShouldContain("_content/Pennington.UI/scripts.js");
+        urls.ShouldContain("_content/Pennington.UI/scripts.js.gz");
+    }
+
+    [Fact]
+    public void Resolve_Indexes_The_Correct_Content_Root_Per_Asset()
+    {
+        var byUrl = StaticWebAssetManifest.Resolve(SampleManifest)
+            .ToDictionary(a => a.UrlPath, a => a.PhysicalPath);
+
+        // The compressed sibling points at a different content root (the obj/compressed dir),
+        // so a naive "all assets share one root" assumption would resolve it wrongly.
+        byUrl["_content/Pennington.UI/scripts.js.gz"]
+            .ShouldBe(Path.Combine("/proj/obj/compressed/", "aaov-{0}-7cod.gz"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not json")]
+    [InlineData("{}")]
+    [InlineData("""{ "ContentRoots": [], "Root": null }""")]
+    [InlineData("""{ "Root": { "Children": null, "Asset": null } }""")]
+    public void Resolve_Returns_Empty_On_Unusable_Input(string json)
+    {
+        StaticWebAssetManifest.Resolve(json).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Resolve_Skips_Assets_With_Out_Of_Range_Content_Root_Index()
+    {
+        const string json =
+            """
+            {
+              "ContentRoots": ["/only/one/"],
+              "Root": { "Children": {
+                "ok.js": { "Children": null, "Asset": { "ContentRootIndex": 0, "SubPath": "ok.js" } },
+                "bad.js": { "Children": null, "Asset": { "ContentRootIndex": 9, "SubPath": "bad.js" } }
+              }, "Asset": null }
+            }
+            """;
+
+        var urls = StaticWebAssetManifest.Resolve(json).Select(a => a.UrlPath).ToList();
+
+        urls.ShouldContain("ok.js");
+        urls.ShouldNotContain("bad.js");
+    }
+
+    [Fact]
+    public void GetManifestPath_Sits_Next_To_The_Assembly()
+    {
+        var assembly = typeof(StaticWebAssetManifest).Assembly;
+
+        var path = StaticWebAssetManifest.GetManifestPath(assembly);
+
+        path.ShouldNotBeNull();
+        path.ShouldEndWith(".staticwebassets.runtime.json");
+        Path.GetDirectoryName(path).ShouldBe(Path.GetDirectoryName(assembly.Location));
+        Path.GetFileName(path).ShouldBe("MonorailCss.Discovery.staticwebassets.runtime.json");
+    }
+}


### PR DESCRIPTION
## Problem

Component packages (RCLs) ship JavaScript under `_content/<Package>/` that builds markup at runtime — e.g. `Pennington.UI`'s `scripts.js`, which constructs a modal using `w-3`/`h-3`. Those files live in the NuGet cache, never enter the assembly IL, and sit outside any watched source directory, so **neither the IL scan nor the source-file scan ever reached them**. Utility classes used only in package JS went undiscovered and their CSS was never generated.

## How it works

The scanner's generic tokenizer already extracts classes from arbitrary JS (confirmed: `scripts.js` literally contains `'w-3 h-3'`). The only missing piece was *finding* the files — so this reads the static web assets manifest to resolve them.

### Runtime — `MonorailCss.Discovery`
- **`StaticWebAssetManifest`** (new) parses `{EntryAssembly}.staticwebassets.runtime.json` (the trie format) and resolves each enumerated asset to its physical path via `ContentRoots[index] + SubPath`.
- **`ClassDiscoveryService`** reads the manifest once at startup, filters by extension + `_content/<Package>` exclusion, and folds the physical paths into the same `SourceFiles` list as ordinary source files — inheriting the existing mtime/incremental token caches.
- **`MonorailDiscoveryOptions`** gains `ScanStaticWebAssets` (default `true`) and `StaticWebAssetExtensions` (`.js`, `.mjs`). Adding a package to `ExcludeAssemblies` also suppresses its assets.

### Build — `MonorailCss.Build.Tasks`
- The targets file depends on `ResolveBuildStaticWebAssets` (the canonical aggregate target; includes package/RCL assets) and forwards `@(StaticWebAsset)` filtered to `.js`/`.mjs` with `AssetRole != Alternative` (drops compressed `.gz`/`.br` siblings) into the task. Gated on `UsingMicrosoftNETSdkRazor` so plain library/console projects build untouched; `MonorailCssScanStaticWebAssets=false` opts out.
- **`ProcessCssTask`** gains a `StaticWebAssets` parameter and honors `SourceId`-based package exclusion.

## Deliberate limitation
Pattern-based content roots (the app's *own* globbed `wwwroot`) aren't expanded — only enumerated assets, which is every package `_content` asset. The app's own `wwwroot` JS lives under the content root the source watcher already covers.

## Verification
- New unit tests: manifest resolution (content-root indexing, URL-path building, malformed input), `.js` tokenization via `SourceFileScanner`, and the build-task path including package exclusion.
- **End-to-end**: `TryMonorail` Release build (Web SDK, references BlazorMonaco) logs `MonorailCss: scanning 114 static web asset file(s)` and builds successfully.
- All affected suites green (`MonorailCss.Tests` 17, `MonorailCss.Build.Tasks.Tests` 8).