### PR TITLE
feat(merging): decompose partially-overridden shorthands into surviving longhands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ MonorailCss is a JIT CSS compiler that aims to be a Tailwind CSS 4.3 compatible 
 
 7. **Variant System** (`src/MonorailCss/Variants/`): Handles pseudo-classes, media queries, and other CSS modifiers. Built-in variants are automatically registered.
 
-8. **Merging System** (`src/MonorailCss/Merging/`): tailwind-merge equivalent (`ClassMerger`, exposed via `CssFramework.Merge`). Conflicts are derived from each class's compiled declarations (with shorthand expansion and a scaffold heuristic for `--tw-*` composition), not from a hand-maintained config — new utilities participate automatically. Utilities with reset semantics (e.g. `touch-none`) override `IUtility.GetMergeInfo` to declare the keys they cover.
+8. **Merging System** (`src/MonorailCss/Merging/`): tailwind-merge equivalent (`ClassMerger`, exposed via `CssFramework.Merge`). Conflicts are derived from each class's compiled declarations (with shorthand expansion and a scaffold heuristic for `--tw-*` composition), not from a hand-maintained config — new utilities participate automatically. Utilities with reset semantics (e.g. `touch-none`) override `IUtility.GetMergeInfo` to declare the keys they cover. When a later longhand only *partially* overrides an earlier shorthand, the shorthand is decomposed into the longhand classes that survive (`my-4 mt-6` → `mb-4 mt-6`) using a one-level class-prefix table (`ShorthandDecomposition`) over the functional axis families. The rewrite is fail-safe — it only commits when it actually drops a conflicting side, and a synthesized child that doesn't round-trip or that writes a key outside the parent (overloaded roots) is rejected, leaving the original class untouched.
 
 ### Key Design Patterns
 

--- a/src/MonorailCss/Merging/ClassMerger.cs
+++ b/src/MonorailCss/Merging/ClassMerger.cs
@@ -83,48 +83,143 @@ public sealed class ClassMerger
     private string MergeCore(string classList)
     {
         var tokens = classList.Split(_whitespace, StringSplitOptions.RemoveEmptyEntries);
-        var keep = new bool[tokens.Length];
 
-        // Right-to-left, mirroring tailwind-merge: a class is dropped when a single later KEPT
-        // class with the same variant chain and importance overrides everything it writes.
+        // Each input position maps to the tokens that survive there: the token itself when kept, an
+        // empty list when dropped, or several longhand tokens when a partially overridden shorthand
+        // is decomposed (my-4 -> mb-4). Flattening these in index order preserves relative order.
+        var outputs = new List<string>[tokens.Length];
+
+        // Right-to-left, mirroring tailwind-merge: a class is dropped when a single later KEPT class
+        // with the same variant chain and importance overrides everything it writes. A class that is
+        // only PARTIALLY overridden is rewritten into the longhand classes that survive — see
+        // DecomposeAndMerge.
         var keptByVariant = new Dictionary<(string VariantKey, bool Important), List<MergeSignature>>();
         for (var i = tokens.Length - 1; i >= 0; i--)
         {
             var signature = GetSignature(tokens[i]);
             if (signature is null)
             {
-                keep[i] = true;
+                outputs[i] = [tokens[i]];
                 continue;
             }
 
             var bucket = (signature.VariantKey, signature.Important);
-            if (keptByVariant.TryGetValue(bucket, out var laterSignatures))
+            if (!keptByVariant.TryGetValue(bucket, out var laterSignatures))
             {
-                if (laterSignatures.Any(later => later.Overrides(signature)))
-                {
-                    continue;
-                }
-
-                laterSignatures.Add(signature);
-            }
-            else
-            {
-                keptByVariant[bucket] = [signature];
+                laterSignatures = [];
+                keptByVariant[bucket] = laterSignatures;
             }
 
-            keep[i] = true;
+            if (laterSignatures.Any(later => later.Overrides(signature)))
+            {
+                // Fully overridden by a single later class — drop it.
+                outputs[i] = [];
+                continue;
+            }
+
+            if (PartiallyOverlaps(signature, laterSignatures) &&
+                DecomposeAndMerge(tokens[i], signature, laterSignatures) is { } decomposed)
+            {
+                outputs[i] = decomposed.Tokens;
+                laterSignatures.AddRange(decomposed.Signatures);
+                continue;
+            }
+
+            outputs[i] = [tokens[i]];
+            laterSignatures.Add(signature);
         }
 
         var kept = new List<string>(tokens.Length);
-        for (var i = 0; i < tokens.Length; i++)
+        foreach (var output in outputs)
         {
-            if (keep[i])
-            {
-                kept.Add(tokens[i]);
-            }
+            kept.AddRange(output);
         }
 
         return string.Join(' ', kept);
+    }
+
+    // True when at least one later kept class writes (or covers) one of this class's keys without a
+    // single later class being a full superset — i.e. the class is partially overridden and a
+    // candidate for decomposition.
+    private static bool PartiallyOverlaps(MergeSignature signature, List<MergeSignature> laterSignatures)
+    {
+        foreach (var later in laterSignatures)
+        {
+            foreach (var write in signature.Writes)
+            {
+                if (later.Writes.Contains(write) || later.Covers.Contains(write))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    // Rewrites a partially overridden shorthand into the longhand classes that survive, recursing so
+    // only the conflicting sub-axis breaks down (m-4 mt-6 -> mx-4 mb-4 mt-6). Returns null — meaning
+    // "keep the original token unchanged" — unless the rewrite actually drops a conflicting side.
+    private (List<string> Tokens, List<MergeSignature> Signatures)? DecomposeAndMerge(
+        string token,
+        MergeSignature parentSignature,
+        List<MergeSignature> laterSignatures)
+    {
+        var children = _signatureBuilder.TryDecompose(token);
+        if (children is null)
+        {
+            return null;
+        }
+
+        var survivorTokens = new List<string>();
+        var survivorSignatures = new List<MergeSignature>();
+
+        // Children share the later-class context and may themselves be kept; track them alongside so
+        // a surviving child participates in conflict checks for the children processed after it.
+        var localLater = new List<MergeSignature>(laterSignatures);
+        var anyOverrideDrop = false;
+
+        foreach (var childToken in children)
+        {
+            var childSignature = GetSignature(childToken);
+            if (childSignature is null)
+            {
+                // Synthesized child didn't round-trip — abandon decomposition, keep the original.
+                return null;
+            }
+
+            if (!childSignature.Writes.IsSubsetOf(parentSignature.Writes))
+            {
+                // Soundness: a child that writes a key the parent didn't (an overloaded root inferring
+                // a different property family) is not a valid decomposition of it — abandon.
+                return null;
+            }
+
+            if (localLater.Any(later => later.Overrides(childSignature)))
+            {
+                // This longhand side is fully overridden by a later class — drop it.
+                anyOverrideDrop = true;
+                continue;
+            }
+
+            if (PartiallyOverlaps(childSignature, localLater) &&
+                DecomposeAndMerge(childToken, childSignature, localLater) is { } nested)
+            {
+                anyOverrideDrop = true;
+                survivorTokens.AddRange(nested.Tokens);
+                survivorSignatures.AddRange(nested.Signatures);
+                localLater.AddRange(nested.Signatures);
+                continue;
+            }
+
+            survivorTokens.Add(childToken);
+            survivorSignatures.Add(childSignature);
+            localLater.Add(childSignature);
+        }
+
+        // Only commit when decomposition removed a conflicting side; otherwise the rewrite is noise
+        // (e.g. a physical/logical mismatch like mx-4 ms-2 where no child is overridden).
+        return anyOverrideDrop ? (survivorTokens, survivorSignatures) : null;
     }
 
     private MergeSignature? GetSignature(string token)

--- a/src/MonorailCss/Merging/ShorthandDecomposition.cs
+++ b/src/MonorailCss/Merging/ShorthandDecomposition.cs
@@ -1,0 +1,70 @@
+using System.Collections.Immutable;
+
+namespace MonorailCss.Merging;
+
+/// <summary>
+/// Decomposes a shorthand utility class-prefix into the longhand class-prefixes it breaks down to,
+/// one level along the natural physical axis. This is the inverse direction of
+/// <see cref="ShorthandExpansion"/>: that one expands a declared CSS <em>property</em> into the
+/// conflict keys it covers, while this one maps a class <em>root</em> (e.g. <c>my</c>) to its
+/// immediate child roots (<c>mt</c>, <c>mb</c>) so <see cref="ClassMerger"/> can rewrite a partially
+/// overridden shorthand into the longhand classes that survive — <c>my-4 mt-6</c> becomes
+/// <c>mb-4 mt-6</c> rather than leaving the ambiguous pair.
+/// </summary>
+/// <remarks>
+/// One level only: each root maps to its <em>immediate</em> coarser children, and leaf roots
+/// (<c>mt</c>, <c>left</c>, <c>w</c>, <c>rounded-tl</c>, …) have no entry. Decomposition recurses
+/// through the table, so a deeper conflict only breaks down the sub-axis it touches and recursion
+/// terminates at the leaves. Scope is the functional axis families whose children map cleanly to a
+/// single physical side; static-utility shorthands (<c>overflow</c>, <c>overscroll</c>,
+/// <c>place-*</c>) and the overloaded <c>border</c> width root are intentionally absent and keep the
+/// plain superset-merge behavior. Every child listed here is a real utility pattern, so a synthesized
+/// child token always re-parses.
+/// </remarks>
+internal static class ShorthandDecomposition
+{
+    private static readonly ImmutableDictionary<string, ImmutableArray<string>> _children = BuildTable();
+
+    /// <summary>
+    /// Returns the immediate child class-prefixes a shorthand root decomposes into along the
+    /// physical axis, or <see langword="null"/> when the root is a leaf or not a recognized
+    /// decomposable shorthand.
+    /// </summary>
+    /// <param name="root">The positive utility root (no leading <c>-</c>), e.g. <c>my</c>.</param>
+    /// <returns>The immediate child roots, or null when the root does not decompose.</returns>
+    public static ImmutableArray<string>? GetChildPrefixes(string root) =>
+        _children.TryGetValue(root, out var children) ? children : null;
+
+    private static ImmutableDictionary<string, ImmutableArray<string>> BuildTable()
+    {
+        var table = new Dictionary<string, ImmutableArray<string>>(StringComparer.Ordinal);
+
+        // Box families share the {B, Bx, By, Bl, Br, Bt, Bb} class-prefix shape.
+        AddBoxFamily(table, "m");
+        AddBoxFamily(table, "p");
+        AddBoxFamily(table, "scroll-m");
+        AddBoxFamily(table, "scroll-p");
+
+        // Inset decomposes through axis roots to the bare physical side roots.
+        table["inset"] = ["inset-x", "inset-y"];
+        table["inset-x"] = ["left", "right"];
+        table["inset-y"] = ["top", "bottom"];
+
+        table["gap"] = ["gap-x", "gap-y"];
+        table["size"] = ["w", "h"];
+
+        // Border-radius: rows then corners — rounded-t/rounded-b together cover all four corners.
+        table["rounded"] = ["rounded-t", "rounded-b"];
+        table["rounded-t"] = ["rounded-tl", "rounded-tr"];
+        table["rounded-b"] = ["rounded-bl", "rounded-br"];
+
+        return table.ToImmutableDictionary(StringComparer.Ordinal);
+    }
+
+    private static void AddBoxFamily(Dictionary<string, ImmutableArray<string>> table, string b)
+    {
+        table[b] = [$"{b}x", $"{b}y"];
+        table[$"{b}x"] = [$"{b}l", $"{b}r"];
+        table[$"{b}y"] = [$"{b}t", $"{b}b"];
+    }
+}

--- a/src/MonorailCss/Merging/SignatureBuilder.cs
+++ b/src/MonorailCss/Merging/SignatureBuilder.cs
@@ -91,6 +91,70 @@ internal sealed class SignatureBuilder
         return new MergeSignature(BuildVariantKey(candidate.Variants), candidate.Important, writes, covers);
     }
 
+    /// <summary>
+    /// Decomposes a shorthand class token into its immediate longhand child tokens (e.g. <c>my-4</c>
+    /// into <c>mt-4</c> and <c>mb-4</c>), preserving variants, negative sign, value, modifier, and
+    /// importance. Returns null when the token is not a decomposable functional shorthand. Used by
+    /// <see cref="ClassMerger"/> to rewrite a partially overridden shorthand into the longhand
+    /// classes that survive; callers re-validate each child via <see cref="ComputeSignature"/>, so an
+    /// imperfectly rendered child simply fails to round-trip and the decomposition is abandoned.
+    /// </summary>
+    /// <param name="token">The raw shorthand class token, e.g. "hover:-my-4".</param>
+    /// <returns>The immediate child tokens in axis order, or null when the token does not decompose.</returns>
+    public IReadOnlyList<string>? TryDecompose(string token)
+    {
+        if (!_parser.TryParseCandidate(token, out var candidate) ||
+            candidate is not FunctionalUtility functional)
+        {
+            return null;
+        }
+
+        var root = functional.Root;
+        var sign = root.StartsWith('-') ? "-" : string.Empty;
+        var positiveRoot = sign.Length > 0 ? root[1..] : root;
+
+        if (ShorthandDecomposition.GetChildPrefixes(positiveRoot) is not { } childPrefixes)
+        {
+            return null;
+        }
+
+        var valuePart = RenderValue(functional.Value);
+        var modifierPart = functional.Modifier is { } modifier ? $"/{modifier}" : string.Empty;
+        var importantPart = functional.Important ? "!" : string.Empty;
+        var variantPart = functional.Variants.IsEmpty
+            ? string.Empty
+            : string.Join(":", functional.Variants.Select(v => v.Raw)) + ":";
+
+        var result = new List<string>(childPrefixes.Length);
+        foreach (var childPrefix in childPrefixes)
+        {
+            result.Add($"{variantPart}{sign}{childPrefix}{valuePart}{modifierPart}{importantPart}");
+        }
+
+        return result;
+    }
+
+    private static string RenderValue(CandidateValue? value)
+    {
+        if (value is null)
+        {
+            return string.Empty;
+        }
+
+        if (value.Kind == ValueKind.Arbitrary)
+        {
+            if (value.IsParenthesesShorthand)
+            {
+                return $"-({value.Value})";
+            }
+
+            return value.DataTypeHint is { } hint ? $"-[{hint}:{value.Value}]" : $"-[{value.Value}]";
+        }
+
+        // Named values carry the full token text (fractions included), so emit them verbatim.
+        return $"-{value.Value}";
+    }
+
     private static bool TryDeriveWrites(ImmutableList<AstNode> nodes, out ImmutableHashSet<string> writes)
     {
         var declarations = new List<(string Context, Declaration Declaration)>();

--- a/tests/MonorailCss.Tests/Merging/ClassMergerTests.cs
+++ b/tests/MonorailCss.Tests/Merging/ClassMergerTests.cs
@@ -15,21 +15,40 @@ public class ClassMergerTests
     [InlineData("bg-red-500 bg-blue-500", "bg-blue-500")]
     [InlineData("w-4 w-8", "w-8")]
     [InlineData("p-4 p-4", "p-4")]
-    // Cross-group shorthands: a shorthand removes its longhands, never the reverse.
+    // Cross-group shorthands: a later shorthand removes its longhands; a later longhand decomposes
+    // an earlier shorthand into the sides that survive.
     [InlineData("px-2 p-4", "p-4")]
-    [InlineData("p-4 px-2", "p-4 px-2")]
+    [InlineData("p-4 px-2", "py-4 px-2")]
     [InlineData("pl-2 px-4", "px-4")]
     [InlineData("ps-2 px-4", "px-4")]
     [InlineData("pt-2 py-4", "py-4")]
     [InlineData("-mt-2 mt-4", "mt-4")]
     [InlineData("mt-4 -mt-2", "-mt-2")]
     [InlineData("rounded-t-md rounded-lg", "rounded-lg")]
-    [InlineData("rounded-lg rounded-t-md", "rounded-lg rounded-t-md")]
+    [InlineData("rounded-lg rounded-t-md", "rounded-b-lg rounded-t-md")]
     [InlineData("left-4 inset-x-2", "inset-x-2")]
     [InlineData("inset-x-2 inset-0", "inset-0")]
     [InlineData("gap-x-2 gap-4", "gap-4")]
     [InlineData("overflow-x-auto overflow-hidden", "overflow-hidden")]
     [InlineData("overflow-hidden overflow-x-auto", "overflow-hidden overflow-x-auto")]
+    // Partial overrides decompose the earlier shorthand into the longhand sides that survive,
+    // breaking down only the conflicting sub-axis and preserving each input's position.
+    [InlineData("my-4 mt-6", "mb-4 mt-6")]
+    [InlineData("m-4 mt-6", "mx-4 mb-4 mt-6")]
+    [InlineData("mb-2 my-4 mt-6", "mb-4 mt-6")]
+    [InlineData("-my-4 mt-6", "-mb-4 mt-6")]
+    [InlineData("my-[10px] mt-4", "mb-[10px] mt-4")]
+    [InlineData("py-4 px-2 pt-1", "pb-4 px-2 pt-1")]
+    [InlineData("inset-x-2 left-4", "right-2 left-4")]
+    [InlineData("gap-4 gap-x-2", "gap-y-4 gap-x-2")]
+    [InlineData("size-4 w-8", "h-4 w-8")]
+    [InlineData("hover:my-4 hover:mt-6", "hover:mb-4 hover:mt-6")]
+    [InlineData("my-4 hover:mt-6", "my-4 hover:mt-6")]
+    [InlineData("my-4! mt-6!", "mb-4! mt-6!")]
+    [InlineData("my-4! mt-6", "my-4! mt-6")]
+    // Decomposition reverts to the original when it would not actually resolve a conflict — here the
+    // physical mx axis and the logical ms side don't reduce to the same longhand.
+    [InlineData("mx-4 ms-2", "mx-4 ms-2")]
     // Deviation from tailwind-merge, matching real CSS: grid-column resets grid-column-start.
     [InlineData("col-start-2 col-span-3", "col-span-3")]
     // Variants isolate conflicts.


### PR DESCRIPTION
## Summary

Extends the class-merging system (`ClassMerger` / `CssFramework.Merge`) so that when a later longhand only *partially* overrides an earlier shorthand, the shorthand is decomposed into the longhand classes that survive — instead of leaving the ambiguous pair untouched.

This matches real CSS cascade semantics for cases tailwind-merge leaves alone:

| Input | Before | After |
|-------|--------|-------|
| `my-4 mt-6` | `my-4 mt-6` | `mb-4 mt-6` |
| `m-4 mt-6` | `m-4 mt-6` | `mx-4 mb-4 mt-6` |
| `rounded-lg rounded-t-md` | `rounded-lg rounded-t-md` | `rounded-b-lg rounded-t-md` |
| `size-4 w-8` | `size-4 w-8` | `h-4 w-8` |

## Changes

- **`ShorthandDecomposition`** (new): a one-level class-prefix table mapping shorthand roots to their immediate physical children over the functional axis families — `m`/`p`/`scroll-m`/`scroll-p` box families, `inset`, `gap`, `size`, and `rounded`. Decomposition recurses through the table so a deeper conflict only breaks down the sub-axis it touches. Static-utility shorthands (`overflow`, `place-*`) and the overloaded `border` root are intentionally absent and keep the plain superset-merge behavior.
- **`SignatureBuilder.TryDecompose`**: expands a shorthand token into its immediate child tokens, preserving variants, negative sign, value, modifier, and importance.
- **`ClassMerger.MergeCore`**: reworked to map each input position to the tokens that survive there (kept, dropped, or decomposed), flattening in index order so relative position is preserved.

## Safety

The rewrite is fail-safe — it only commits when it actually drops a conflicting side. A synthesized child that doesn't round-trip, or one that writes a key outside the parent (overloaded roots), is rejected, leaving the original class untouched. Mismatched physical/logical axes like `mx-4 ms-2` revert to the original.

## Testing

All 84 `ClassMergerTests` pass, including new cases for axis decomposition, negatives, arbitrary values, modifiers, variants (`hover:`), importance (`!`), and the no-op revert cases.