### PR TITLE
fix(discovery): synchronize watcher lists to stop shutdown race

### DIFF
--- a/src/MonorailCss.Discovery/ClassDiscoveryService.cs
+++ b/src/MonorailCss.Discovery/ClassDiscoveryService.cs
@@ -23,6 +23,7 @@ internal sealed partial class ClassDiscoveryService : IHostedService, IClassRegi
     private readonly List<FileSystemWatcher> _fileWatchers = new();
     private readonly List<FileSystemWatcher> _cssWatchers = new();
     private readonly Lock _lock = new();
+    private readonly Lock _watcherLock = new();
     private readonly Timer _debounce;
     private readonly Timer _cssDebounce;
     private readonly Timer _lateLoadDebounce;
@@ -33,6 +34,7 @@ internal sealed partial class ClassDiscoveryService : IHostedService, IClassRegi
     private int _regenerateCount;
     private int _hotReloadCount;
     private bool _started;
+    private bool _stopping; // guarded by _watcherLock; once set, watchers are never (re)started
     private List<string>? _staticWebAssetFiles;
 
     public ClassDiscoveryService(
@@ -199,6 +201,7 @@ internal sealed partial class ClassDiscoveryService : IHostedService, IClassRegi
     {
         AppDomain.CurrentDomain.AssemblyLoad -= OnAssemblyLoad;
         MonorailCssReloader.UnregisterService(this);
+        BeginStopping();
         StopFileWatchers();
         StopCssFileWatchers();
         return Task.CompletedTask;
@@ -208,6 +211,7 @@ internal sealed partial class ClassDiscoveryService : IHostedService, IClassRegi
     {
         AppDomain.CurrentDomain.AssemblyLoad -= OnAssemblyLoad;
         MonorailCssReloader.UnregisterService(this);
+        BeginStopping();
         StopFileWatchers();
         StopCssFileWatchers();
         _debounce.Dispose();
@@ -215,53 +219,82 @@ internal sealed partial class ClassDiscoveryService : IHostedService, IClassRegi
         _lateLoadDebounce.Dispose();
     }
 
+    /// <summary>
+    /// Marks the service as shutting down and disarms the debounce timers. Setting
+    /// <see cref="_stopping"/> under <see cref="_watcherLock"/> ensures any in-flight debounce
+    /// tick that's about to (re)start watchers observes the flag and bails, so the watcher lists
+    /// can't be mutated concurrently with — or resurrected after — the stop below.
+    /// </summary>
+    private void BeginStopping()
+    {
+        lock (_watcherLock)
+        {
+            _stopping = true;
+        }
+
+        _debounce.Change(Timeout.Infinite, Timeout.Infinite);
+        _cssDebounce.Change(Timeout.Infinite, Timeout.Infinite);
+        _lateLoadDebounce.Change(Timeout.Infinite, Timeout.Infinite);
+    }
+
     private void StartFileWatchers()
     {
-        foreach (var dir in _options.WatchSourceDirectories)
+        lock (_watcherLock)
         {
-            if (!Directory.Exists(dir))
+            if (_stopping)
             {
-                LogMonorailcssDiscoveryWatchsourcedirectoriesEntryDirDoesNotExist(dir);
-                continue;
+                return;
             }
 
-            var watcher = new FileSystemWatcher(dir)
+            foreach (var dir in _options.WatchSourceDirectories)
             {
-                IncludeSubdirectories = true,
-                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.Size,
-                EnableRaisingEvents = true,
-            };
+                if (!Directory.Exists(dir))
+                {
+                    LogMonorailcssDiscoveryWatchsourcedirectoriesEntryDirDoesNotExist(dir);
+                    continue;
+                }
 
-            watcher.Filters.Add("*.razor");
-            watcher.Filters.Add("*.cshtml");
-            watcher.Filters.Add("*.cs");
-            watcher.Filters.Add("*.html");
+                var watcher = new FileSystemWatcher(dir)
+                {
+                    IncludeSubdirectories = true,
+                    NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.Size,
+                    EnableRaisingEvents = true,
+                };
 
-            watcher.Changed += OnSourceFileChanged;
-            watcher.Created += OnSourceFileChanged;
-            watcher.Renamed += OnSourceFileRenamed;
+                watcher.Filters.Add("*.razor");
+                watcher.Filters.Add("*.cshtml");
+                watcher.Filters.Add("*.cs");
+                watcher.Filters.Add("*.html");
 
-            _fileWatchers.Add(watcher);
-            LogMonorailcssDiscoveryWatchingSourceDirectoryDir(dir);
+                watcher.Changed += OnSourceFileChanged;
+                watcher.Created += OnSourceFileChanged;
+                watcher.Renamed += OnSourceFileRenamed;
+
+                _fileWatchers.Add(watcher);
+                LogMonorailcssDiscoveryWatchingSourceDirectoryDir(dir);
+            }
         }
     }
 
     private void StopFileWatchers()
     {
-        foreach (var w in _fileWatchers)
+        lock (_watcherLock)
         {
-            try
+            foreach (var w in _fileWatchers)
             {
-                w.EnableRaisingEvents = false;
-                w.Dispose();
+                try
+                {
+                    w.EnableRaisingEvents = false;
+                    w.Dispose();
+                }
+                catch
+                {
+                    // best-effort
+                }
             }
-            catch
-            {
-                // best-effort
-            }
-        }
 
-        _fileWatchers.Clear();
+            _fileWatchers.Clear();
+        }
     }
 
     /// <summary>
@@ -272,65 +305,83 @@ internal sealed partial class ClassDiscoveryService : IHostedService, IClassRegi
     /// </summary>
     private void StartCssFileWatchers()
     {
-        if (_result.ImportedCssFiles.Count == 0)
+        lock (_watcherLock)
         {
-            return;
-        }
-
-        if (_environment != null && !_environment.IsDevelopment())
-        {
-            return;
-        }
-
-        var byDirectory = _result.ImportedCssFiles
-            .Where(p => !string.IsNullOrEmpty(p))
-            .GroupBy(p => Path.GetDirectoryName(p) ?? string.Empty, StringComparer.OrdinalIgnoreCase);
-
-        foreach (var group in byDirectory)
-        {
-            var dir = group.Key;
-            if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
+            if (_stopping || _result.ImportedCssFiles.Count == 0)
             {
-                continue;
+                return;
             }
 
-            var watcher = new FileSystemWatcher(dir)
+            if (_environment != null && !_environment.IsDevelopment())
             {
-                IncludeSubdirectories = false,
-                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.Size,
-                EnableRaisingEvents = true,
-            };
-
-            foreach (var file in group)
-            {
-                watcher.Filters.Add(Path.GetFileName(file));
+                return;
             }
 
-            watcher.Changed += OnCssFileChanged;
-            watcher.Created += OnCssFileChanged;
-            watcher.Renamed += OnCssFileRenamed;
+            var byDirectory = _result.ImportedCssFiles
+                .Where(p => !string.IsNullOrEmpty(p))
+                .GroupBy(p => Path.GetDirectoryName(p) ?? string.Empty, StringComparer.OrdinalIgnoreCase);
 
-            _cssWatchers.Add(watcher);
-            LogMonorailcssDiscoveryWatchingCssInDirCountFiles(dir, group.Count());
+            foreach (var group in byDirectory)
+            {
+                var dir = group.Key;
+                if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
+                {
+                    continue;
+                }
+
+                var watcher = new FileSystemWatcher(dir)
+                {
+                    IncludeSubdirectories = false,
+                    NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.Size,
+                    EnableRaisingEvents = true,
+                };
+
+                foreach (var file in group)
+                {
+                    watcher.Filters.Add(Path.GetFileName(file));
+                }
+
+                watcher.Changed += OnCssFileChanged;
+                watcher.Created += OnCssFileChanged;
+                watcher.Renamed += OnCssFileRenamed;
+
+                _cssWatchers.Add(watcher);
+                LogMonorailcssDiscoveryWatchingCssInDirCountFiles(dir, group.Count());
+            }
         }
     }
 
     private void StopCssFileWatchers()
     {
-        foreach (var w in _cssWatchers)
+        lock (_watcherLock)
         {
-            try
+            foreach (var w in _cssWatchers)
             {
-                w.EnableRaisingEvents = false;
-                w.Dispose();
+                try
+                {
+                    w.EnableRaisingEvents = false;
+                    w.Dispose();
+                }
+                catch
+                {
+                    // best-effort
+                }
             }
-            catch
-            {
-                // best-effort
-            }
-        }
 
-        _cssWatchers.Clear();
+            _cssWatchers.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Test seam: drives the same watcher stop/restart cycle the CSS debounce timer triggers
+    /// (minus the surrounding regeneration), so concurrency tests can collide watcher churn
+    /// with <see cref="StopAsync"/>/<see cref="Dispose"/> and guard against the
+    /// unsynchronized-list race this class fixes.
+    /// </summary>
+    internal void RestartCssFileWatchersForTests()
+    {
+        StopCssFileWatchers();
+        StartCssFileWatchers();
     }
 
     private void OnCssFileChanged(object sender, FileSystemEventArgs e) => QueueCssReload();

--- a/tests/MonorailCss.Tests/Discovery/DiscoverySourceCssIntegrationTests.cs
+++ b/tests/MonorailCss.Tests/Discovery/DiscoverySourceCssIntegrationTests.cs
@@ -196,6 +196,61 @@ public class DiscoverySourceCssIntegrationTests
         }
     }
 
+    [Fact]
+    public async Task CssFileWatcher_Restart_Racing_Shutdown_Does_Not_Throw()
+    {
+        // Regression: the CSS debounce timer restarts the watcher list on a thread-pool thread
+        // while host shutdown (StopAsync/Dispose) iterates the same list, throwing
+        // "Collection was modified; enumeration operation may not execute." Hammer the restart
+        // cycle from several threads, then tear the service down underneath them — the
+        // synchronized watcher lists must keep every operation safe.
+        var dir = TempDir();
+        try
+        {
+            var cssPath = Path.Combine(dir, "app.css");
+            File.WriteAllText(cssPath, "@theme { --color-brand: blue; }");
+
+            // No environment => dev-only gate is skipped, so the CSS watcher is actually created.
+            var (service, _) = CreateService(o => o.SourceCssPath = cssPath);
+            var failures = new System.Collections.Concurrent.ConcurrentQueue<Exception>();
+
+            using (service)
+            {
+                await service.StartAsync(CancellationToken.None);
+
+                using var cts = new CancellationTokenSource();
+                var churn = Enumerable.Range(0, 4).Select(_ => Task.Run(() =>
+                {
+                    try
+                    {
+                        while (!cts.IsCancellationRequested)
+                        {
+                            service.RestartCssFileWatchersForTests();
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        failures.Enqueue(ex);
+                    }
+                })).ToArray();
+
+                // Let the churn run against a live (un-stopping) service — this is the window
+                // where the unsynchronized list would blow up — then collide it with shutdown.
+                await Task.Delay(100, TestContext.Current.CancellationToken);
+                await service.StopAsync(CancellationToken.None);
+
+                cts.Cancel();
+                await Task.WhenAll(churn);
+            }
+
+            failures.ShouldBeEmpty();
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
     private static (ClassDiscoveryService Service, MonorailDiscoveryOptions Options) CreateService(Action<MonorailDiscoveryOptions>? configure = null)
     {
         var options = new MonorailDiscoveryOptions();


### PR DESCRIPTION
## Problem

A consuming app (Pennington integration tests) hit a crash during host teardown:

```
System.InvalidOperationException : Collection was modified; enumeration operation may not execute.
   at MonorailCss.Discovery.ClassDiscoveryService.StopCssFileWatchers()
   at MonorailCss.Discovery.ClassDiscoveryService.StopAsync(CancellationToken)
   at Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory`1.Dispose()
```

## Root cause

`ClassDiscoveryService` keeps two plain `List<FileSystemWatcher>` fields (`_fileWatchers`, `_cssWatchers`) with **no synchronization**. The CSS-debounce timer callback `OnCssDebounceTick` runs on a thread-pool thread and rebuilds the list (`StopCssFileWatchers()` then `StartCssFileWatchers()`). When host shutdown (`StopAsync`/`Dispose`) iterated `_cssWatchers` at the same time a pending debounce tick was mutating it, the two threads collided → `Collection was modified`.

## Fix

- Added a dedicated `_watcherLock` and wrapped the bodies of all four watcher methods (`Start/StopFileWatchers`, `Start/StopCssFileWatchers`) in it, so iteration and mutation can never overlap.
- Added a `_stopping` flag (guarded by the lock) set via `BeginStopping()` at the top of `StopAsync`/`Dispose`, which also disarms the debounce timers. The locked `Start*` methods bail when `_stopping` is set — this also closes a latent second bug where a late timer tick could **resurrect watchers after the host disposed them**.

No lock nesting is introduced, so there's no deadlock risk.

## Test

Added `CssFileWatcher_Restart_Racing_Shutdown_Does_Not_Throw`, which collides watcher churn from 4 threads with shutdown. To keep it deterministic (not dependent on OS file-watcher timing) it drives the timer's exact restart path via a small `internal RestartCssFileWatchersForTests` seam. Verified the test reproduces the **exact** original stack trace when the lock is removed, and passes with the fix.

All 6 Discovery integration tests pass; project builds with 0 warnings.