### PR TITLE
feat(discovery): source-generated utility registry (trim/AOT-safe)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ MonorailCss is a JIT CSS compiler that aims to be a Tailwind CSS 4.3 compatible 
 
 ### Key Design Patterns
 
-- **Auto-Discovery**: Utilities are automatically discovered via reflection at startup
+- **Auto-Discovery**: Utilities are discovered at **compile time** by a Roslyn source generator (`src/MonorailCss.SourceGenerator`), which emits `GeneratedUtilityRegistry.CreateAll()` — an explicit `new XUtility()` list for every concrete `IUtility` with a parameterless constructor. `UtilityDiscovery.DiscoverAllUtilities()` consumes it. This keeps the library trim-safe / AOT-compatible (no `Assembly.GetTypes()`/`Activator.CreateInstance`) and avoids an assembly scan on every `CssFramework` construction. The generator is referenced build-only (`OutputItemType="Analyzer"`, not shipped to consumers). Utilities exposing exact static names that aren't `BaseStaticUtility` (e.g. `inset-shadow`, `drop-shadow`, `mask`, `outline-hidden`) implement `IStaticUtilityNameProvider` so the registry can index them without reflection. Both `MonorailCss` and `MonorailCss.Discovery` are marked `<IsAotCompatible>`.
 - **Priority System**: Utilities have priorities (0-1000) determining evaluation order
 - **Immutable Data**: Extensive use of immutable collections
 - **Pipeline Architecture**: Modular stages for processing transformations

--- a/MonorailCss.sln
+++ b/MonorailCss.sln
@@ -31,6 +31,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonorailCss.Build.Tasks", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonorailCss.Build.Tasks.Tests", "tests\MonorailCss.Build.Tasks.Tests\MonorailCss.Build.Tasks.Tests.csproj", "{08ACD7FE-5E55-493A-9EF2-8FC6262F0536}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonorailCss.SourceGenerator", "src\MonorailCss.SourceGenerator\MonorailCss.SourceGenerator.csproj", "{9ABB6D5F-126F-48DB-B73A-D512C76A6B44}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -173,6 +175,18 @@ Global
 		{08ACD7FE-5E55-493A-9EF2-8FC6262F0536}.Release|x64.Build.0 = Release|Any CPU
 		{08ACD7FE-5E55-493A-9EF2-8FC6262F0536}.Release|x86.ActiveCfg = Release|Any CPU
 		{08ACD7FE-5E55-493A-9EF2-8FC6262F0536}.Release|x86.Build.0 = Release|Any CPU
+		{9ABB6D5F-126F-48DB-B73A-D512C76A6B44}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9ABB6D5F-126F-48DB-B73A-D512C76A6B44}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9ABB6D5F-126F-48DB-B73A-D512C76A6B44}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9ABB6D5F-126F-48DB-B73A-D512C76A6B44}.Debug|x64.Build.0 = Debug|Any CPU
+		{9ABB6D5F-126F-48DB-B73A-D512C76A6B44}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9ABB6D5F-126F-48DB-B73A-D512C76A6B44}.Debug|x86.Build.0 = Debug|Any CPU
+		{9ABB6D5F-126F-48DB-B73A-D512C76A6B44}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9ABB6D5F-126F-48DB-B73A-D512C76A6B44}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9ABB6D5F-126F-48DB-B73A-D512C76A6B44}.Release|x64.ActiveCfg = Release|Any CPU
+		{9ABB6D5F-126F-48DB-B73A-D512C76A6B44}.Release|x64.Build.0 = Release|Any CPU
+		{9ABB6D5F-126F-48DB-B73A-D512C76A6B44}.Release|x86.ActiveCfg = Release|Any CPU
+		{9ABB6D5F-126F-48DB-B73A-D512C76A6B44}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -189,5 +203,6 @@ Global
 		{97E5BF2E-CBD5-4148-BEEA-5602A49EEE81} = {208BA388-4CEE-2CBF-559C-5607C099C1F8}
 		{07BF4948-3A48-4631-8A72-EEEF9D2C5986} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{08ACD7FE-5E55-493A-9EF2-8FC6262F0536} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{9ABB6D5F-126F-48DB-B73A-D512C76A6B44} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/src/MonorailCss.Discovery/ClassDiscoveryService.cs
+++ b/src/MonorailCss.Discovery/ClassDiscoveryService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -162,6 +163,10 @@ internal sealed partial class ClassDiscoveryService : IHostedService, IClassRegi
     /// in <see cref="AppDomain.CurrentDomain"/> by the time the generator runs, even if the
     /// host (e.g. ASP.NET Core, Blazor) hasn't touched a type from them yet.
     /// </summary>
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' may break when trimming",
+        Justification = "Runtime class discovery is inherently a reflection feature: it walks the entry assembly's reference graph to force-load component packages. Under trimming the graph may be incomplete, in which case discovery simply finds fewer classes — the load is best-effort and guarded. AddMonorailClassDiscovery documents that this feature is unsuitable for fully-trimmed/Native-AOT deployments.")]
     private void ForceLoadEntryAssemblyReferences()
     {
         var entry = Assembly.GetEntryAssembly();

--- a/src/MonorailCss.Discovery/DiscoveryJsonSerializerContext.cs
+++ b/src/MonorailCss.Discovery/DiscoveryJsonSerializerContext.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace MonorailCss.Discovery;
+
+/// <summary>
+/// System.Text.Json source-generation context for the discovery diagnostics endpoint. Using a
+/// generated context (rather than reflection-based <c>JsonSerializer.Serialize</c>) keeps the
+/// diagnostics endpoint trim- and AOT-safe.
+/// </summary>
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(DiagnosticsSnapshot))]
+internal sealed partial class DiscoveryJsonSerializerContext : JsonSerializerContext;

--- a/src/MonorailCss.Discovery/MonorailCss.Discovery.csproj
+++ b/src/MonorailCss.Discovery/MonorailCss.Discovery.csproj
@@ -11,6 +11,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsAotCompatible>true</IsAotCompatible>
     <Description>Runtime CSS class discovery for MonorailCSS — scans loaded assembly IL to extract utility classes from .razor, .cs, and compiled NuGet packages without source generators or build tasks.</Description>
     <Copyright>Phil Scott</Copyright>
     <PackageProjectUrl>https://github.com/phil-scott-78/monorail</PackageProjectUrl>

--- a/src/MonorailCss.Discovery/MonorailCssMiddleware.cs
+++ b/src/MonorailCss.Discovery/MonorailCssMiddleware.cs
@@ -12,11 +12,6 @@ namespace MonorailCss.Discovery;
 /// </summary>
 internal sealed class MonorailCssMiddleware
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        WriteIndented = true,
-    };
-
     private readonly RequestDelegate _next;
     private readonly ClassDiscoveryService _service;
     private readonly MonorailDiscoveryOptions _options;
@@ -84,7 +79,8 @@ internal sealed class MonorailCssMiddleware
         var snapshot = _service.GetDiagnostics();
         context.Response.ContentType = "application/json; charset=utf-8";
         context.Response.Headers[HeaderNames.CacheControl] = "no-store";
-        await context.Response.WriteAsync(JsonSerializer.Serialize(snapshot, JsonOptions));
+        await context.Response.WriteAsync(
+            JsonSerializer.Serialize(snapshot, DiscoveryJsonSerializerContext.Default.DiagnosticsSnapshot));
     }
 
     private static string TrimExtension(string endpoint)

--- a/src/MonorailCss.Discovery/ServiceCollectionExtensions.cs
+++ b/src/MonorailCss.Discovery/ServiceCollectionExtensions.cs
@@ -34,6 +34,13 @@ public static class MonorailCssServiceCollectionExtensions
     /// <param name="services">The service collection.</param>
     /// <param name="configure">Optional callback to override the auto-detected defaults.</param>
     /// <returns>The same service collection for chaining.</returns>
+    /// <remarks>
+    /// Discovery inspects loaded assemblies at runtime (reference-graph walk, IL metadata scan,
+    /// static web asset manifests). This is fundamentally a reflection feature: under aggressive
+    /// trimming or Native AOT the assembly graph and on-disk paths may be incomplete, so discovery
+    /// degrades gracefully to finding fewer classes rather than failing. It is intended for
+    /// JIT/development and standard server deployments, not fully-trimmed single-file/AOT apps.
+    /// </remarks>
     public static IServiceCollection AddMonorailClassDiscovery(
         this IServiceCollection services,
         Action<MonorailDiscoveryOptions>? configure = null)

--- a/src/MonorailCss.Discovery/StaticWebAssetManifest.cs
+++ b/src/MonorailCss.Discovery/StaticWebAssetManifest.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -42,6 +43,10 @@ public static class StaticWebAssetManifest
     /// </summary>
     /// <param name="assembly">The assembly whose manifest to locate — typically the entry assembly.</param>
     /// <returns>The expected manifest path, or <see langword="null"/> when it can't be derived.</returns>
+    [UnconditionalSuppressMessage(
+        "SingleFile",
+        "IL3000:Avoid accessing Assembly file path when publishing as a single file",
+        Justification = "An empty Location (single-file/Native-AOT) is handled below by returning null, so no static web asset manifest is resolved and discovery degrades gracefully.")]
     public static string? GetManifestPath(Assembly assembly)
     {
         var location = assembly.Location;

--- a/src/MonorailCss.SourceGenerator/IsExternalInit.cs
+++ b/src/MonorailCss.SourceGenerator/IsExternalInit.cs
@@ -1,0 +1,7 @@
+// Polyfill so records / init-only setters compile on netstandard2.0 (required for Roslyn analyzers).
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit
+    {
+    }
+}

--- a/src/MonorailCss.SourceGenerator/MonorailCss.SourceGenerator.csproj
+++ b/src/MonorailCss.SourceGenerator/MonorailCss.SourceGenerator.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <!-- Build-only analyzer used by MonorailCss itself; never packed or shipped. -->
+    <IsPackable>false</IsPackable>
+    <Deterministic>true</Deterministic>
+    <DebugType>embedded</DebugType>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\stylecop.json" Link="Properties/stylecop.json" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/src/MonorailCss.SourceGenerator/UtilityRegistryGenerator.cs
+++ b/src/MonorailCss.SourceGenerator/UtilityRegistryGenerator.cs
@@ -1,0 +1,294 @@
+using System.Collections.Immutable;
+using System.Text;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MonorailCss.SourceGenerator;
+
+/// <summary>
+/// Emits, at compile time, two artifacts for every concrete <c>IUtility</c> in the compilation
+/// that has a parameterless constructor:
+/// <list type="bullet">
+/// <item><c>GeneratedUtilityRegistry.CreateAll()</c> — an explicit array of <c>new</c> calls,
+/// replacing the reflection (<c>Assembly.GetTypes()</c> + <c>Activator.CreateInstance</c>) that
+/// <c>UtilityDiscovery</c> used.</item>
+/// <item><c>GeneratedUtilityMetadata</c> — a <c>FrozenDictionary&lt;Type, Entry&gt;</c> of
+/// documentation metadata (category, summary, support flags), replacing the runtime XML-doc parse
+/// and base-type reflection in <c>UtilityMetadata.FromUtilityType</c>.</item>
+/// </list>
+/// Both keep the assembly trim-safe and AOT-compatible and move work to build time.
+/// </summary>
+[Generator]
+public sealed class UtilityRegistryGenerator : IIncrementalGenerator
+{
+    private const string IUtilityMetadataName = "MonorailCss.Utilities.IUtility";
+
+    /// <inheritdoc/>
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var utilities = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                predicate: static (node, _) => node is ClassDeclarationSyntax { BaseList: not null },
+                transform: static (ctx, _) => GetUtilityModel(ctx))
+            .Where(static model => model is not null)
+            .Select(static (model, _) => model!)
+            .Collect();
+
+        context.RegisterSourceOutput(utilities, static (spc, models) => Emit(spc, models));
+    }
+
+    private static UtilityModel? GetUtilityModel(GeneratorSyntaxContext context)
+    {
+        var declaration = (ClassDeclarationSyntax)context.Node;
+
+        if (context.SemanticModel.GetDeclaredSymbol(declaration) is not INamedTypeSymbol symbol)
+        {
+            return null;
+        }
+
+        // Mirror the old reflection filter: concrete class, not abstract/static, implements
+        // IUtility (directly or via a base class), and has an accessible parameterless constructor.
+        if (symbol.TypeKind != TypeKind.Class || symbol.IsAbstract || symbol.IsStatic)
+        {
+            return null;
+        }
+
+        if (!ImplementsUtilityInterface(symbol))
+        {
+            return null;
+        }
+
+        if (!HasAccessibleParameterlessConstructor(symbol))
+        {
+            return null;
+        }
+
+        return new UtilityModel(
+            symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            InferCategory(symbol),
+            GenerateDescription(symbol),
+            SupportsModifiers(symbol),
+            SupportsArbitraryValues(symbol));
+    }
+
+    private static bool ImplementsUtilityInterface(INamedTypeSymbol symbol)
+    {
+        foreach (var iface in symbol.AllInterfaces)
+        {
+            if (iface.ToDisplayString() == IUtilityMetadataName)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasAccessibleParameterlessConstructor(INamedTypeSymbol symbol)
+    {
+        foreach (var ctor in symbol.InstanceConstructors)
+        {
+            if (ctor.Parameters.Length != 0)
+            {
+                continue;
+            }
+
+            // Generated code lives in the same assembly, so public/internal/protected-internal
+            // parameterless constructors are all reachable (an undeclared ctor is implicitly public).
+            if (ctor.DeclaredAccessibility is Accessibility.Public
+                or Accessibility.Internal
+                or Accessibility.ProtectedOrInternal)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Category is the namespace segment following "Utilities" (e.g. MonorailCss.Utilities.Layout
+    // -> "Layout"), matching UtilityMetadata.InferCategory.
+    private static string InferCategory(INamedTypeSymbol symbol)
+    {
+        var ns = symbol.ContainingNamespace?.ToDisplayString() ?? string.Empty;
+        var parts = ns.Split('.');
+        var index = Array.IndexOf(parts, "Utilities");
+        if (index >= 0 && index < parts.Length - 1)
+        {
+            return parts[index + 1];
+        }
+
+        return "General";
+    }
+
+    // Prefer the type's XML <summary>; fall back to the same humanised name heuristic the runtime
+    // used, so built-in descriptions are byte-for-byte what reflection produced — just computed once.
+    private static string GenerateDescription(INamedTypeSymbol symbol)
+    {
+        var summary = TryGetXmlSummary(symbol);
+        if (!string.IsNullOrEmpty(summary))
+        {
+            return summary!;
+        }
+
+        var name = symbol.Name;
+        if (name.EndsWith("Utility", StringComparison.Ordinal))
+        {
+            name = name.Substring(0, name.Length - "Utility".Length);
+        }
+
+        var spaced = new StringBuilder(name.Length * 2);
+        foreach (var ch in name)
+        {
+            if (char.IsUpper(ch) && spaced.Length > 0)
+            {
+                spaced.Append(' ');
+            }
+
+            spaced.Append(ch);
+        }
+
+        return $"Handles {spaced.ToString().Trim().ToLowerInvariant()} utilities";
+    }
+
+    private static string? TryGetXmlSummary(INamedTypeSymbol symbol)
+    {
+        var xml = symbol.GetDocumentationCommentXml();
+        if (string.IsNullOrWhiteSpace(xml))
+        {
+            return null;
+        }
+
+        try
+        {
+            var summary = XDocument.Parse(xml).Descendants("summary").FirstOrDefault();
+            if (summary == null)
+            {
+                return null;
+            }
+
+            // Mirror UtilityMetadata.CleanXmlDocText: trim each line, drop blanks, join with a space.
+            var lines = summary.Value
+                .Split('\n')
+                .Select(line => line.Trim())
+                .Where(line => line.Length > 0);
+            var cleaned = string.Join(" ", lines);
+            return cleaned.Length == 0 ? null : cleaned;
+        }
+        catch (System.Xml.XmlException)
+        {
+            return null;
+        }
+    }
+
+    private static bool SupportsModifiers(INamedTypeSymbol symbol) =>
+        InheritsFrom(symbol, "BaseColorUtility");
+
+    private static bool SupportsArbitraryValues(INamedTypeSymbol symbol) =>
+        InheritsFrom(symbol, "BaseFunctionalUtility")
+        || InheritsFrom(symbol, "BaseSpacingUtility")
+        || InheritsFrom(symbol, "BaseFilterUtility")
+        || InheritsFrom(symbol, "BaseColorUtility");
+
+    private static bool InheritsFrom(INamedTypeSymbol symbol, string baseTypeName)
+    {
+        for (var current = symbol.BaseType; current is not null; current = current.BaseType)
+        {
+            if (current.Name == baseTypeName)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void Emit(SourceProductionContext context, ImmutableArray<UtilityModel> models)
+    {
+        // Partial classes surface multiple syntax nodes; dedupe by name and sort for deterministic output.
+        var distinct = models
+            .GroupBy(m => m.FullyQualifiedName, System.StringComparer.Ordinal)
+            .Select(g => g.First())
+            .OrderBy(m => m.FullyQualifiedName, System.StringComparer.Ordinal)
+            .ToList();
+
+        context.AddSource("GeneratedUtilityRegistry.g.cs", EmitRegistry(distinct));
+        context.AddSource("GeneratedUtilityMetadata.g.cs", EmitMetadata(distinct));
+    }
+
+    private static string EmitRegistry(List<UtilityModel> models)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated/>");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
+        sb.AppendLine("namespace MonorailCss.Utilities;");
+        sb.AppendLine();
+        sb.AppendLine("/// <summary>");
+        sb.AppendLine("/// Source-generated registration of every built-in <see cref=\"IUtility\"/>.");
+        sb.AppendLine("/// Replaces reflection-based discovery so the assembly is trim- and AOT-safe.");
+        sb.AppendLine("/// </summary>");
+        sb.AppendLine("internal static class GeneratedUtilityRegistry");
+        sb.AppendLine("{");
+        sb.AppendLine("    /// <summary>Creates one instance of every discovered utility.</summary>");
+        sb.AppendLine("    internal static global::MonorailCss.Utilities.IUtility[] CreateAll() =>");
+        sb.AppendLine("    [");
+        foreach (var model in models)
+        {
+            sb.Append("        new ").Append(model.FullyQualifiedName).AppendLine("(),");
+        }
+
+        sb.AppendLine("    ];");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static string EmitMetadata(List<UtilityModel> models)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated/>");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
+        sb.AppendLine("using System;");
+        sb.AppendLine("using System.Collections.Frozen;");
+        sb.AppendLine("using System.Collections.Generic;");
+        sb.AppendLine();
+        sb.AppendLine("namespace MonorailCss.Utilities;");
+        sb.AppendLine();
+        sb.AppendLine("/// <summary>");
+        sb.AppendLine("/// Source-generated documentation metadata for every built-in utility. Replaces the runtime");
+        sb.AppendLine("/// XML-doc parse and base-type reflection in <see cref=\"global::MonorailCss.Documentation.UtilityMetadata\"/>.");
+        sb.AppendLine("/// </summary>");
+        sb.AppendLine("internal static class GeneratedUtilityMetadata");
+        sb.AppendLine("{");
+        sb.AppendLine("    /// <summary>Documentation facts known at compile time for a utility type.</summary>");
+        sb.AppendLine("    internal readonly record struct Entry(string Category, string Description, bool SupportsModifiers, bool SupportsArbitraryValues);");
+        sb.AppendLine();
+        sb.AppendLine("    private static readonly FrozenDictionary<Type, Entry> Map = new Dictionary<Type, Entry>");
+        sb.AppendLine("    {");
+        foreach (var model in models)
+        {
+            sb.Append("        [typeof(").Append(model.FullyQualifiedName).Append(")] = new Entry(")
+              .Append(SymbolDisplay.FormatLiteral(model.Category, quote: true)).Append(", ")
+              .Append(SymbolDisplay.FormatLiteral(model.Description, quote: true)).Append(", ")
+              .Append(model.SupportsModifiers ? "true" : "false").Append(", ")
+              .Append(model.SupportsArbitraryValues ? "true" : "false").AppendLine("),");
+        }
+
+        sb.AppendLine("    }.ToFrozenDictionary();");
+        sb.AppendLine();
+        sb.AppendLine("    /// <summary>Looks up compile-time metadata for a built-in utility type.</summary>");
+        sb.AppendLine("    internal static bool TryGet(Type type, out Entry entry) => Map.TryGetValue(type, out entry);");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private sealed record UtilityModel(
+        string FullyQualifiedName,
+        string Category,
+        string Description,
+        bool SupportsModifiers,
+        bool SupportsArbitraryValues);
+}

--- a/src/MonorailCss/Documentation/UtilityMetadata.cs
+++ b/src/MonorailCss/Documentation/UtilityMetadata.cs
@@ -1,6 +1,4 @@
-using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
-using System.Xml.Linq;
 
 namespace MonorailCss.Documentation;
 
@@ -100,25 +98,38 @@ public partial class UtilityMetadata
     public static UtilityMetadata FromUtilityType(Type utilityType, Utilities.IUtility? utilityInstance = null)
     {
         var name = utilityType.Name;
-        var category = InferCategory(utilityType);
-        var description = GenerateDescription(utilityType);
+        string category;
+        string description;
+        bool supportsModifiers;
+        bool supportsArbitraryValues;
 
-        // Detect support for modifiers and arbitrary values based on base class
-        var supportsModifiers = IsColorUtility(utilityType);
-        var supportsArbitraryValues = IsFunctionalUtility(utilityType) || IsColorUtility(utilityType);
+        // Built-in utilities have their category, summary, and support flags computed at compile
+        // time by the source generator — no XML-doc file parse or base-type reflection at runtime.
+        if (Utilities.GeneratedUtilityMetadata.TryGet(utilityType, out var generated))
+        {
+            category = generated.Category;
+            description = generated.Description;
+            supportsModifiers = generated.SupportsModifiers;
+            supportsArbitraryValues = generated.SupportsArbitraryValues;
+        }
+        else
+        {
+            // Fallback for types the generator didn't see (e.g. consumer-authored custom utilities).
+            // Uses only namespace + base-type inspection; no Assembly.Location / XML-doc file access.
+            // Custom utilities that want a richer description can override IUtility.GetMetadata().
+            category = InferCategory(utilityType);
+            description = GenerateHeuristicDescription(utilityType);
+            supportsModifiers = IsColorUtility(utilityType);
+            supportsArbitraryValues = IsFunctionalUtility(utilityType) || IsColorUtility(utilityType);
+        }
 
-        // Extract documented properties
+        // Extract documented properties from the live instance (requires compilation, so it stays
+        // a runtime step regardless of where the rest of the metadata comes from).
         string[]? documentedProperties = null;
         if (utilityInstance != null)
         {
-            // First, try to get documented properties from the utility itself
-            documentedProperties = utilityInstance.GetDocumentedProperties();
-
-            // If not specified, extract from compiled CSS
-            if (documentedProperties == null)
-            {
-                documentedProperties = ExtractDocumentedPropertiesFromUtility(utilityInstance);
-            }
+            documentedProperties = utilityInstance.GetDocumentedProperties()
+                ?? ExtractDocumentedPropertiesFromUtility(utilityInstance);
         }
 
         return new UtilityMetadata(name, category, description, supportsModifiers, supportsArbitraryValues, documentedProperties);
@@ -141,15 +152,11 @@ public partial class UtilityMetadata
         return "General";
     }
 
-    private static string GenerateDescription(Type utilityType)
+    // Reflection-free description for types the generator didn't see: strip the "Utility" suffix
+    // and humanise the PascalCase name. Built-in utilities never reach this — their description
+    // (XML <summary> or this same heuristic) is baked in at compile time by the source generator.
+    private static string GenerateHeuristicDescription(Type utilityType)
     {
-        // Try to extract XML documentation summary first
-        if (TryGetXmlDocSummary(utilityType, out var xmlSummary))
-        {
-            return xmlSummary;
-        }
-
-        // Fallback: Remove "Utility" suffix and convert to readable format
         var name = utilityType.Name;
         if (name.EndsWith("Utility"))
         {
@@ -159,108 +166,6 @@ public partial class UtilityMetadata
         // Convert PascalCase to space-separated words
         var result = ConvertPascalCaseToSpaceSeperatedRegex().Replace(name, " $1").Trim();
         return $"Handles {result.ToLowerInvariant()} utilities";
-    }
-
-    // The XML documentation file for an assembly is large (hundreds of KB) and never changes
-    // for a process's lifetime, yet GenerateDescription is called for every utility (and twice
-    // per utility on the default-metadata path). Parsing it with XDocument.Load on every lookup
-    // dominated documentation generation (~0.5s per full pass, ~1s+ for the double-call path).
-    // Parse it once per assembly into a member-name → summary map; subsequent lookups are O(1).
-    private static readonly ConcurrentDictionary<string, IReadOnlyDictionary<string, string>> XmlSummaryCache = new();
-
-    private static bool TryGetXmlDocSummary(Type type, out string summary)
-    {
-        summary = string.Empty;
-
-        try
-        {
-            // Get the XML documentation file path
-            var assemblyLocation = type.Assembly.Location;
-            if (string.IsNullOrEmpty(assemblyLocation))
-            {
-                return false;
-            }
-
-            var summaries = GetXmlSummaries(assemblyLocation);
-
-            // Construct the member name for the type (format: "T:Namespace.TypeName")
-            var memberName = $"T:{type.FullName}";
-            if (summaries.TryGetValue(memberName, out var cached) && !string.IsNullOrWhiteSpace(cached))
-            {
-                summary = cached;
-                return true;
-            }
-
-            return false;
-        }
-        catch
-        {
-            // If anything goes wrong, return false to use fallback
-            return false;
-        }
-    }
-
-    /// <summary>
-    /// Loads and parses the XML documentation for an assembly exactly once, returning a map of
-    /// member name (e.g. "T:Namespace.TypeName") to its cleaned summary text. The empty map is
-    /// cached when no XML file is present, so the (missing) file is probed only once.
-    /// </summary>
-    private static IReadOnlyDictionary<string, string> GetXmlSummaries(string assemblyLocation)
-    {
-        return XmlSummaryCache.GetOrAdd(assemblyLocation, static loc =>
-        {
-            var map = new Dictionary<string, string>(StringComparer.Ordinal);
-
-            try
-            {
-                var xmlPath = Path.ChangeExtension(loc, ".xml");
-                if (!File.Exists(xmlPath))
-                {
-                    return map;
-                }
-
-                var doc = XDocument.Load(xmlPath);
-                foreach (var member in doc.Descendants("member"))
-                {
-                    var name = member.Attribute("name")?.Value;
-                    if (string.IsNullOrEmpty(name))
-                    {
-                        continue;
-                    }
-
-                    var summaryElement = member.Element("summary");
-                    if (summaryElement == null)
-                    {
-                        continue;
-                    }
-
-                    // First entry wins (matches the previous FirstOrDefault semantics).
-                    map.TryAdd(name, CleanXmlDocText(summaryElement.Value));
-                }
-            }
-            catch
-            {
-                // On any parse error, cache whatever was collected (possibly empty) so we don't retry.
-            }
-
-            return map;
-        });
-    }
-
-    private static string CleanXmlDocText(string text)
-    {
-        if (string.IsNullOrWhiteSpace(text))
-        {
-            return string.Empty;
-        }
-
-        // Split into lines and trim each
-        var lines = text.Split('\n')
-            .Select(line => line.Trim())
-            .Where(line => !string.IsNullOrWhiteSpace(line));
-
-        // Join with a single space
-        return string.Join(" ", lines);
     }
 
     private static bool IsFunctionalUtility(Type utilityType)

--- a/src/MonorailCss/MonorailCss.csproj
+++ b/src/MonorailCss/MonorailCss.csproj
@@ -12,6 +12,7 @@
     <Nullable>enable</Nullable>
     <Description>MonorailCSS is a JIT CSS compiler inspired by Tailwind CSS</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsAotCompatible>true</IsAotCompatible>
     <Copyright>Phil Scott</Copyright>
     <PackageProjectUrl>https://github.com/phil-scott-78/monorail</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -28,6 +29,11 @@
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" Link="Properties/stylecop.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Build-only: generates GeneratedUtilityRegistry into this assembly. Not shipped to consumers. -->
+    <ProjectReference Include="..\MonorailCss.SourceGenerator\MonorailCss.SourceGenerator.csproj"
+                      OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations.Sources" Version="2025.2.4">

--- a/src/MonorailCss/Parser/Custom/StaticCustomUtility.cs
+++ b/src/MonorailCss/Parser/Custom/StaticCustomUtility.cs
@@ -10,7 +10,7 @@ namespace MonorailCss.Parser.Custom;
 /// A custom utility implementation for static CSS patterns defined via @utility directives.
 /// Handles both simple property mappings and complex nested selectors.
 /// </summary>
-public class StaticCustomUtility : IUtility
+public class StaticCustomUtility : IUtility, IStaticUtilityNameProvider
 {
     private readonly UtilityDefinition _definition;
 
@@ -58,6 +58,13 @@ public class StaticCustomUtility : IUtility
     /// </summary>
     /// <returns>The utility name as a string, derived from the pattern in the definition.</returns>
     public string GetUtilityName() => _definition.Pattern;
+
+    /// <summary>
+    /// Gets the exact class name this custom utility handles, used by the registry to index it
+    /// without reflection.
+    /// </summary>
+    /// <returns>A single-element sequence containing the utility's pattern.</returns>
+    public IEnumerable<string> GetUtilityNames() => [_definition.Pattern];
 
     /// <summary>
     /// Attempts to compile the specified candidate into Abstract Syntax Tree (AST) nodes

--- a/src/MonorailCss/Utilities/Borders/OutlineHiddenUtility.cs
+++ b/src/MonorailCss/Utilities/Borders/OutlineHiddenUtility.cs
@@ -8,13 +8,13 @@ namespace MonorailCss.Utilities.Borders;
 /// <summary>
 /// Utilities for hiding the outline of an element while maintaining accessibility.
 /// </summary>
-internal class OutlineHiddenUtility : IUtility
+internal class OutlineHiddenUtility : IUtility, IStaticUtilityNameProvider
 {
     public UtilityPriority Priority => UtilityPriority.ExactStatic;
 
     public string[] GetNamespaces() => [];
 
-    public string GetUtilityName() => "outline-hidden";
+    public IEnumerable<string> GetUtilityNames() => ["outline-hidden"];
 
     public bool TryCompile(Candidate candidate, Theme.Theme theme, out ImmutableList<AstNode>? results)
     {

--- a/src/MonorailCss/Utilities/CLAUDE.md
+++ b/src/MonorailCss/Utilities/CLAUDE.md
@@ -80,10 +80,13 @@ public class OpacityUtility : BaseFunctionalUtility
 ## Architecture & Registration
 
 ### Auto-Discovery System
-- `UtilityDiscovery.DiscoverAllUtilities()` uses reflection
-- Finds all concrete classes implementing `IUtility`
-- Requires parameterless constructor
-- Automatic registration via `DesignSystem.RegisterAllUtilities()`
+- Utilities are discovered at **compile time** by the Roslyn source generator in
+  `src/MonorailCss.SourceGenerator`, which emits `GeneratedUtilityRegistry.CreateAll()`
+- `UtilityDiscovery.DiscoverAllUtilities()` consumes the generated list (no reflection — trim/AOT safe)
+- The generator includes every concrete class implementing `IUtility` with a parameterless constructor,
+  so a new utility participates automatically; no manual registration is needed
+- Utilities that expose exact static names but don't extend `BaseStaticUtility` must implement
+  `IStaticUtilityNameProvider` to be indexed by the registry
 
 ### Priority System
 ```csharp

--- a/src/MonorailCss/Utilities/Effects/InsetShadowUtility.cs
+++ b/src/MonorailCss/Utilities/Effects/InsetShadowUtility.cs
@@ -18,13 +18,13 @@ namespace MonorailCss.Utilities.Effects;
 /// <see cref="InsetShadowColorUtility"/>. <c>@property --tw-inset-shadow</c> is registered centrally
 /// by <c>PropertyRegistrationStage</c>.
 /// </remarks>
-internal class InsetShadowUtility : IUtility
+internal class InsetShadowUtility : IUtility, IStaticUtilityNameProvider
 {
     public UtilityPriority Priority => UtilityPriority.ExactStatic;
 
     public string[] GetNamespaces() => [];
 
-    public string[] GetUtilityNames() => [.. _insetShadows.Keys];
+    public IEnumerable<string> GetUtilityNames() => [.. _insetShadows.Keys];
 
     public string[] GetFunctionalRoots() => ["inset-shadow"];
 

--- a/src/MonorailCss/Utilities/Effects/MaskUtility.cs
+++ b/src/MonorailCss/Utilities/Effects/MaskUtility.cs
@@ -7,7 +7,7 @@ namespace MonorailCss.Utilities.Effects;
 /// <summary>
 /// Utilities for controlling how an element is masked or clipped using mask images and gradients.
 /// </summary>
-internal class MaskUtility : IUtility
+internal class MaskUtility : IUtility, IStaticUtilityNameProvider
 {
     private static readonly Dictionary<string, (string Property, string Value)> _staticMappings = new()
     {
@@ -122,7 +122,7 @@ internal class MaskUtility : IUtility
     /// Gets the names of all static utilities handled by this class.
     /// Required for UtilityRegistry to properly index static utilities.
     /// </summary>
-    public static string[] GetUtilityNames() => _staticMappings.Keys.ToArray();
+    public IEnumerable<string> GetUtilityNames() => _staticMappings.Keys.ToArray();
 
     /// <inheritdoc/>
     public bool TryCompile(Candidate candidate, Theme.Theme theme, out ImmutableList<AstNode>? results)

--- a/src/MonorailCss/Utilities/Filters/DropShadowUtility.cs
+++ b/src/MonorailCss/Utilities/Filters/DropShadowUtility.cs
@@ -16,13 +16,13 @@ namespace MonorailCss.Utilities.Filters;
 /// static names; <c>@property</c> blocks for both variables are registered centrally by
 /// <c>PropertyRegistrationStage</c>.
 /// </remarks>
-internal class DropShadowUtility : IUtility
+internal class DropShadowUtility : IUtility, IStaticUtilityNameProvider
 {
     public UtilityPriority Priority => UtilityPriority.ExactStatic;
 
     public string[] GetNamespaces() => [];
 
-    public string[] GetUtilityNames() => [.. _dropShadows.Keys];
+    public IEnumerable<string> GetUtilityNames() => [.. _dropShadows.Keys];
 
     public string[] GetFunctionalRoots() => ["drop-shadow"];
 

--- a/src/MonorailCss/Utilities/IStaticUtilityNameProvider.cs
+++ b/src/MonorailCss/Utilities/IStaticUtilityNameProvider.cs
@@ -1,0 +1,17 @@
+namespace MonorailCss.Utilities;
+
+/// <summary>
+/// Implemented by utilities that expose a fixed set of exact (static) class names but are not
+/// <see cref="Base.BaseStaticUtility"/> subclasses. <see cref="UtilityRegistry"/> uses this to
+/// index those names without reflection. Implement this on a custom <see cref="IUtility"/> when its
+/// names must be matched exactly by the parser before functional roots are considered.
+/// </summary>
+public interface IStaticUtilityNameProvider
+{
+    /// <summary>
+    /// Gets the exact class names this utility handles (e.g. <c>inset-shadow-sm</c>,
+    /// <c>outline-hidden</c>).
+    /// </summary>
+    /// <returns>The static class names handled by this utility.</returns>
+    IEnumerable<string> GetUtilityNames();
+}

--- a/src/MonorailCss/Utilities/UtilityDiscovery.cs
+++ b/src/MonorailCss/Utilities/UtilityDiscovery.cs
@@ -1,84 +1,21 @@
-using System.Reflection;
-
 namespace MonorailCss.Utilities;
 
 /// <summary>
-/// Discovers and creates instances of all utilities that implement IUtility.
+/// Provides the set of built-in utilities. The list is produced at compile time by the
+/// MonorailCss source generator (<c>GeneratedUtilityRegistry</c>) rather than by reflecting over
+/// the assembly, so the library is trim-safe and AOT-compatible and construction avoids an
+/// assembly scan plus a per-utility <c>Activator.CreateInstance</c>.
 /// </summary>
 internal static class UtilityDiscovery
 {
     /// <summary>
-    /// Discovers all concrete utilities that implement IUtility in the current assembly.
+    /// Returns one instance of every built-in utility, ordered by priority then type name to
+    /// preserve the deterministic evaluation order the reflection-based discovery used.
     /// </summary>
     public static IEnumerable<IUtility> DiscoverAllUtilities()
     {
-        return DiscoverUtilitiesFromAssembly(Assembly.GetExecutingAssembly());
-    }
-
-    /// <summary>
-    /// Discovers all utilities from specified assemblies.
-    /// </summary>
-    public static IEnumerable<IUtility> DiscoverUtilitiesFromAssemblies(params Assembly[] assemblies)
-    {
-        var utilities = new List<IUtility>();
-
-        foreach (var assembly in assemblies)
-        {
-            utilities.AddRange(DiscoverUtilitiesFromAssembly(assembly));
-        }
-
-        // Sort by priority (the utilities themselves define their priority)
-        return utilities
+        return GeneratedUtilityRegistry.CreateAll()
             .OrderBy(u => u.Priority)
-            .ThenBy(u => u.GetType().Name);
-    }
-
-    /// <summary>
-    /// Discovers utilities from a specific assembly.
-    /// </summary>
-    public static IEnumerable<IUtility> DiscoverUtilitiesFromAssembly(Assembly assembly)
-    {
-        var utilityTypes = assembly.GetTypes()
-            .Where(t => t.IsClass && !t.IsAbstract)
-            .Where(t => typeof(IUtility).IsAssignableFrom(t))
-            .Where(t => t.GetConstructor(Type.EmptyTypes) != null) // Has parameterless constructor
-            .ToList();
-
-        var utilities = new List<IUtility>();
-
-        foreach (var type in utilityTypes)
-        {
-            if (TryCreateInstance(type, out var instance))
-            {
-                utilities.Add(instance);
-            }
-        }
-
-        return utilities
-            .OrderBy(u => u.Priority)
-            .ThenBy(u => u.GetType().Name);
-    }
-
-    private static bool TryCreateInstance(Type type, out IUtility instance)
-    {
-        instance = null!;
-
-        try
-        {
-            // Look for a parameterless constructor
-            var constructor = type.GetConstructor(Type.EmptyTypes);
-            if (constructor != null)
-            {
-                instance = (IUtility)Activator.CreateInstance(type)!;
-                return true;
-            }
-        }
-        catch (Exception ex)
-        {
-            // Could log the error if needed
-            Console.WriteLine($"Failed to create instance of {type.Name}: {ex.Message}");
-        }
-
-        return false;
+            .ThenBy(u => u.GetType().Name, StringComparer.Ordinal);
     }
 }

--- a/src/MonorailCss/UtilityRegistry.cs
+++ b/src/MonorailCss/UtilityRegistry.cs
@@ -55,36 +55,21 @@ internal class UtilityRegistry
             }
         }
 
-        // Index custom static utilities that have a GetUtilityName or GetUtilityNames method
+        // Index static utilities that expose exact names but aren't BaseStaticUtility (built-ins
+        // like inset-shadow/drop-shadow/mask/outline-hidden, plus custom @utility definitions).
+        // Implementing IStaticUtilityNameProvider replaces the previous reflection-based duck typing,
+        // keeping this path trim- and AOT-safe.
         foreach (var customUtility in _utilities)
         {
-            // Skip if already handled as BaseStaticUtility
             if (customUtility is BaseStaticUtility)
             {
                 continue;
             }
 
-            // Check if it has a GetUtilityNames method (plural)
-            var getUtilityNamesMethod = customUtility.GetType().GetMethod("GetUtilityNames");
-            if (getUtilityNamesMethod != null && getUtilityNamesMethod.ReturnType == typeof(string[]))
+            if (customUtility is IStaticUtilityNameProvider nameProvider)
             {
-                var utilityNames = getUtilityNamesMethod.Invoke(customUtility, null) as string[];
-                if (utilityNames != null)
+                foreach (var utilityName in nameProvider.GetUtilityNames())
                 {
-                    foreach (var utilityName in utilityNames)
-                    {
-                        dictionary.TryAdd(utilityName, customUtility);
-                    }
-                }
-            }
-
-            // Check if it has a GetUtilityName method (like our StaticCustomUtility)
-            else
-            {
-                var getUtilityNameMethod = customUtility.GetType().GetMethod("GetUtilityName");
-                if (getUtilityNameMethod != null && getUtilityNameMethod.ReturnType == typeof(string))
-                {
-                    var utilityName = getUtilityNameMethod.Invoke(customUtility, null) as string;
                     if (!string.IsNullOrEmpty(utilityName))
                     {
                         dictionary.TryAdd(utilityName, customUtility);

--- a/tests/MonorailCss.Benchmarks/Program.cs
+++ b/tests/MonorailCss.Benchmarks/Program.cs
@@ -7,7 +7,24 @@ using MonorailCss.Discovery;
 // Use BenchmarkSwitcher so individual benchmarks can be targeted from the command line, e.g.
 //   dotnet run -c Release -- --filter '*GenerationBenchmark*'
 // With no args it runs every benchmark, matching the previous BenchmarkRunner.Run behaviour.
-BenchmarkSwitcher.FromTypes(new[] { typeof(GenerationBenchmark), typeof(ScanningBenchmark) }).Run(args);
+BenchmarkSwitcher.FromTypes(new[] { typeof(ConstructionBenchmark), typeof(GenerationBenchmark), typeof(ScanningBenchmark) }).Run(args);
+
+/// <summary>
+/// Measures the one-time cost of standing up a <see cref="CssFramework"/>. This is dominated by
+/// utility registration: before the source generator this meant an <c>Assembly.GetTypes()</c> scan
+/// plus an <c>Activator.CreateInstance</c> per utility; after, it is a single array of <c>new</c>
+/// calls. <see cref="Construct"/> isolates that cost; <see cref="ConstructAndProcessOnce"/> covers
+/// the realistic "spin up and emit once" usage so cold-start gains are visible end to end.
+/// </summary>
+[MemoryDiagnoser]
+public class ConstructionBenchmark
+{
+    [Benchmark]
+    public CssFramework Construct() => new CssFramework();
+
+    [Benchmark]
+    public string ConstructAndProcessOnce() => new CssFramework().Process(SampleData.Classes);
+}
 
 /// <summary>
 /// Measures the generation hot path — turning a known set of class names into CSS.


### PR DESCRIPTION
## Summary

Replaces the reflection-based utility discovery with a compile-time Roslyn source generator, making the library trim-safe / AOT-compatible and removing the per-construction assembly scan.

Previously, every `CssFramework` construction scanned the assembly with `Assembly.GetTypes()` and instantiated each utility via `Activator.CreateInstance`, and documentation metadata was produced by parsing the assembly's XML-doc file at runtime. Both are incompatible with trimming / Native AOT and add cold-start cost.

## What changed

- **New `MonorailCss.SourceGenerator`** — an incremental Roslyn generator that emits:
  - `GeneratedUtilityRegistry.CreateAll()` — an explicit `new XUtility()` list for every concrete `IUtility` with a parameterless constructor.
  - `GeneratedUtilityMetadata` — a `FrozenDictionary<Type, Entry>` of compile-time documentation facts (category, summary, support flags), replacing the runtime XML-doc parse + base-type reflection.
  - Referenced build-only (`OutputItemType="Analyzer"`, `ReferenceOutputAssembly="false"`, `PrivateAssets="all"`); never packed or shipped to consumers.
- **`UtilityDiscovery.DiscoverAllUtilities()`** now consumes the generated list (same priority-then-name ordering preserved); reflection paths removed.
- **`UtilityMetadata.FromUtilityType`** reads generated metadata first, falling back to namespace + base-type inspection for consumer-authored utilities the generator didn't see. The XML-doc file parse/cache is gone.
- **`IStaticUtilityNameProvider`** replaces the registry's reflection-based duck typing (`GetType().GetMethod("GetUtilityNames")`). Implemented on `OutlineHidden`, `InsetShadow`, `Mask`, `DropShadow`, and `StaticCustomUtility`.
- **AOT/trim safety**: `<IsAotCompatible>` on both `MonorailCss` and `MonorailCss.Discovery`; a `System.Text.Json` source-gen context (`DiscoveryJsonSerializerContext`) for the discovery diagnostics endpoint; and documented `UnconditionalSuppressMessage` justifications for the unavoidable trim/single-file warnings in the runtime discovery path (which degrades gracefully rather than failing).
- **`ConstructionBenchmark`** added to measure the cold-start gain (`Construct` and `ConstructAndProcessOnce`).
- Docs updated (`CLAUDE.md`, `Utilities/CLAUDE.md`).

## Testing

- `dotnet build` — 0 warnings, 0 errors.
- `dotnet test` — all **7,197** tests pass.
