### PR TITLE
ci: tag-driven releases with multi-OS build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,41 @@
 name: ci
 
+# Build + test everywhere; publish only on a version tag.
+#
+# Releases are tag-driven so the published version is deterministic: the publish job
+# runs ON the tagged commit (github.ref_type == 'tag'), so MinVer resolves the exact
+# version every time and there is no race between merging to main and pushing the tag.
+#
+# Cutting a release:
+#   1. Merge to main.
+#   2. git tag 0.1.1 && git push origin 0.1.1   (unprefixed, matches MinVer's tag scheme)
+#   -> the tag build publishes the packages to NuGet and creates the GitHub release.
+#
+# Pattern adapted from xoofx's dotnet-releaser templates (xoofx/.github), kept in-repo
+# rather than referenced so the token-bearing publish step runs only our own pinned code.
+
 on:
   push:
-    paths-ignore:
-    - 'changelog.md'
-    - 'license.md'
-    - 'readme.md'
-    - 'src/TryMonorail/**'
     branches: [main]
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'      # stable, e.g. 0.1.0
+      - '[0-9]+.[0-9]+.[0-9]+-*'    # prerelease, e.g. 0.1.0-rc.1
   pull_request:
-    paths-ignore:
-    - 'changelog.md'
-    - 'license.md'
-    - 'readme.md'
-    - 'src/TryMonorail/**'
     branches: [main]
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: build (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout
@@ -30,8 +47,35 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         global-json-file: global.json
-    - name: Build, Test (Debug & Release); publish on main/tag
+
+    - name: Build, Test, Pack (no publish)
       shell: bash
       run: |
         dotnet tool install --global dotnet-releaser
-        dotnet-releaser run --nuget-token "${{secrets.NUGET_TOKEN}}" --github-token "${{secrets.GITHUB_TOKEN}}" dotnet-releaser.toml
+        dotnet-releaser build dotnet-releaser.toml
+
+  publish:
+    name: publish
+    needs: build
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create the GitHub release
+      actions: write    # upload release assets
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Install .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        global-json-file: global.json
+
+    - name: Build, Test, Pack, Publish
+      shell: bash
+      run: |
+        dotnet tool install --global dotnet-releaser
+        dotnet-releaser run --nuget-token "${{ secrets.NUGET_TOKEN }}" --github-token "${{ secrets.GITHUB_TOKEN }}" dotnet-releaser.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,27 @@
 name: ci
 
-# Build + test everywhere; publish only on a version tag.
+# Build + test on every push/PR (multi-OS); a single publish job runs `dotnet-releaser run`
+# on every push and lets dotnet-releaser decide what to do from the git ref:
 #
-# Releases are tag-driven so the published version is deterministic: the publish job
-# runs ON the tagged commit (github.ref_type == 'tag'), so MinVer resolves the exact
-# version every time and there is no race between merging to main and pushing the tag.
+#   - push to main  -> publishes a per-commit PRERELEASE package to NuGet
+#                      ([nuget] publish_draft = true in dotnet-releaser.toml) and refreshes
+#                      the rolling `draft-main` GitHub release notes. These are the "alphas".
+#   - push of a tag -> publishes the STABLE version to NuGet and creates the GitHub release.
+#   - pull request  -> build + test only (publish job is skipped; no tokens exposed).
 #
-# Cutting a release:
+# Releases are deterministic because the tag build runs ON the tagged commit, so MinVer
+# resolves the exact version every time -- no race between merging to main and pushing the tag.
+# (Per dotnet-releaser's docs, publishing requires the action to run on the tag push, which is
+# why `tags:` is in the trigger below.)
+#
+# Cutting a stable release:
 #   1. Merge to main.
-#   2. git tag 0.1.1 && git push origin 0.1.1   (unprefixed, matches MinVer's tag scheme)
-#   -> the tag build publishes the packages to NuGet and creates the GitHub release.
+#   2. git tag 0.1.1 && git push origin 0.1.1   (unprefixed, matches MinVer / github.version_prefix="")
+#   -> the tag build publishes 0.1.1 to NuGet and creates the GitHub release.
 #
-# Pattern adapted from xoofx's dotnet-releaser templates (xoofx/.github), kept in-repo
-# rather than referenced so the token-bearing publish step runs only our own pinned code.
+# Pattern adapted from xoofx's dotnet-releaser templates (xoofx/.github), kept in-repo rather
+# than referenced so the token-bearing publish step runs only our own pinned code. We publish on
+# every push (not tag-only like his multi-OS template) to keep the per-commit prerelease packages.
 
 on:
   push:
@@ -57,7 +66,9 @@ jobs:
   publish:
     name: publish
     needs: build
-    if: github.ref_type == 'tag'
+    # Run on every push (main or tag), never on PRs. dotnet-releaser itself reads the git ref:
+    # main push -> prerelease NuGet package + draft-main notes; tag push -> stable release.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write   # create the GitHub release


### PR DESCRIPTION
Makes publishing deterministic so the version race we hit cutting `0.1.0` can't recur — **while keeping the per-commit prerelease (alpha) packages**.

## Problem
CI ran `dotnet-releaser run` on every `main` push, but had **no `tags:` trigger**, so pushing a version tag built nothing. The published version was whatever MinVer computed at checkout, so a stable version only appeared if the tag was already on the commit — a race between *merge-to-main* and *push-tag*. (Cutting `0.1.0` needed a manual re-run, and its GitHub release had to be created by hand.)

## How dotnet-releaser actually behaves (from its docs)
`dotnet-releaser run` reads the git ref and acts accordingly:
- **PR / non-release branch** → build + test only.
- **push to a release branch** (`main`, per `github.branches`) → with **`[nuget] publish_draft = true`** (already set), pushes the **per-commit prerelease package** to NuGet and refreshes a rolling `draft-main` release. ← the alphas.
- **push of a version tag** → publishes the **stable** version to NuGet and creates the GitHub release.

The docs are explicit that publishing "relies on … the GitHub action being run on that tag commit" — so the trigger must include tags.

## Fix
Adapted from xoofx's `dotnet-releaser` templates (`xoofx/.github`), kept **in-repo** (not via `uses:`) so the `NUGET_TOKEN`-bearing publish runs only our own pinned code.

- Trigger on `main` pushes, PRs, and version tags (`0.1.0`, `0.1.0-rc.1`).
- **`build`** (windows/macos/ubuntu matrix): `dotnet-releaser build` — build + test + pack, **never publishes** — on every push/PR. Cross-OS quality gate.
- **`publish`** (`needs: build`, `if: github.event_name == 'push'`): `dotnet-releaser run`. Runs on every push (not PRs); dotnet-releaser then does the alpha on `main` and the stable release on a tag.

Net result:
| event | build matrix (3 OS) | publish |
|---|---|---|
| pull request | ✅ | skipped |
| push to `main` | ✅ | prerelease package to NuGet + `draft-main` notes |
| push tag `X.Y.Z` | ✅ | stable release to NuGet + GitHub release |

Because the tag build runs **on the tagged commit**, MinVer resolves the exact version — no race — and the GitHub release is created automatically.

## New stable-release procedure
```
merge to main
git tag 0.1.1 && git push origin 0.1.1     # unprefixed, matches github.version_prefix=""
# -> tag build publishes 0.1.1 to NuGet + creates the GitHub release
```

## Notes
- Dropped the previous `paths-ignore` — it referenced lowercase `changelog.md`/`readme.md` that didn't match the real file casing on Linux, and path filters interact badly with tag pushes (xoofx's templates use none).
- Diverges from xoofx's multi-OS template in one intentional way: he publishes tag-only; we publish on every push to keep the alphas.

## Already done (out of band)
- `0.1.0` is live on NuGet (all three packages); its GitHub release was created manually since the old workflow couldn't.