### PR TITLE
perf/per token compile cache

### DIFF
--- a/src/MonorailCss/Ast/AstNode.cs
+++ b/src/MonorailCss/Ast/AstNode.cs
@@ -31,12 +31,25 @@ public abstract record AstNode
     public abstract string ToCss(int indentLevel = 0);
 
     /// <summary>
+    /// Writes this node's CSS representation directly into <paramref name="sb"/>, without the
+    /// trailing newline (callers add the separator, mirroring the old <c>AppendLine(node.ToCss())</c>
+    /// pattern). This is the allocation-free serialization path: nodes append straight into one
+    /// shared buffer instead of each building its own string for the parent to copy. The default
+    /// delegates to <see cref="ToCss"/> so any node type that hasn't overridden it still works.
+    /// </summary>
+    internal virtual void WriteCss(StringBuilder sb, int indentLevel = 0) => sb.Append(ToCss(indentLevel));
+
+    /// <summary>
     /// Generates a string consisting of a specified number of spaces for use as an indentation in the CSS representation.
     /// Each level corresponds to two spaces.
     /// </summary>
     /// <param name="level">The number of indentation levels to generate. Each level adds two spaces.</param>
     /// <returns>A string of spaces representing the specified indentation level.</returns>
     protected static string GetIndent(int level) => new string(' ', level * 2);
+
+    /// <summary>Appends <paramref name="level"/> levels of indentation (two spaces each) directly,
+    /// without allocating an intermediate string the way <see cref="GetIndent"/> does.</summary>
+    private protected static void AppendIndent(StringBuilder sb, int level) => sb.Append(' ', level * 2);
 }
 
 /// <summary>
@@ -51,9 +64,22 @@ public record Declaration(string Property, string Value, bool Important = false)
     /// <inheritdoc />
     public override string ToCss(int indentLevel = 0)
     {
-        var indent = GetIndent(indentLevel);
-        var importantStr = Important ? " !important" : string.Empty;
-        return $"{indent}{Property}: {Value}{importantStr};";
+        var sb = new StringBuilder();
+        WriteCss(sb, indentLevel);
+        return sb.ToString();
+    }
+
+    /// <inheritdoc />
+    internal override void WriteCss(StringBuilder sb, int indentLevel = 0)
+    {
+        AppendIndent(sb, indentLevel);
+        sb.Append(Property).Append(": ").Append(Value);
+        if (Important)
+        {
+            sb.Append(" !important");
+        }
+
+        sb.Append(';');
     }
 }
 
@@ -64,18 +90,23 @@ internal record StyleRule(string Selector, ImmutableList<AstNode> Nodes) : AstNo
     public override string ToCss(int indentLevel = 0)
     {
         var sb = new StringBuilder();
-        var indent = GetIndent(indentLevel);
+        WriteCss(sb, indentLevel);
+        return sb.ToString();
+    }
 
-        sb.AppendLine($"{indent}{Selector} {{");
+    internal override void WriteCss(StringBuilder sb, int indentLevel = 0)
+    {
+        AppendIndent(sb, indentLevel);
+        sb.Append(Selector).Append(" {").AppendLine();
 
         foreach (var node in Nodes)
         {
-            sb.AppendLine(node.ToCss(indentLevel + 1));
+            node.WriteCss(sb, indentLevel + 1);
+            sb.AppendLine();
         }
 
-        sb.Append($"{indent}}}");
-
-        return sb.ToString();
+        AppendIndent(sb, indentLevel);
+        sb.Append('}');
     }
 }
 
@@ -86,19 +117,24 @@ internal record NestedRule(string Selector, ImmutableList<AstNode> Nodes) : AstN
     public override string ToCss(int indentLevel = 0)
     {
         var sb = new StringBuilder();
-        var indent = GetIndent(indentLevel);
+        WriteCss(sb, indentLevel);
+        return sb.ToString();
+    }
 
+    internal override void WriteCss(StringBuilder sb, int indentLevel = 0)
+    {
         // Nested rules use & parent selector syntax
-        sb.AppendLine($"{indent}{Selector} {{");
+        AppendIndent(sb, indentLevel);
+        sb.Append(Selector).Append(" {").AppendLine();
 
         foreach (var node in Nodes)
         {
-            sb.AppendLine(node.ToCss(indentLevel + 1));
+            node.WriteCss(sb, indentLevel + 1);
+            sb.AppendLine();
         }
 
-        sb.Append($"{indent}}}");
-
-        return sb.ToString();
+        AppendIndent(sb, indentLevel);
+        sb.Append('}');
     }
 }
 
@@ -109,26 +145,35 @@ internal record AtRule(string Name, string Params, ImmutableList<AstNode> Nodes)
     public override string ToCss(int indentLevel = 0)
     {
         var sb = new StringBuilder();
-        var indent = GetIndent(indentLevel);
-        var paramsStr = string.IsNullOrEmpty(Params) ? string.Empty : $" {Params}";
+        WriteCss(sb, indentLevel);
+        return sb.ToString();
+    }
+
+    internal override void WriteCss(StringBuilder sb, int indentLevel = 0)
+    {
+        AppendIndent(sb, indentLevel);
+        sb.Append('@').Append(Name);
+        if (!string.IsNullOrEmpty(Params))
+        {
+            sb.Append(' ').Append(Params);
+        }
 
         if (Nodes.IsEmpty)
         {
-            sb.Append($"{indent}@{Name}{paramsStr};");
+            sb.Append(';');
+            return;
         }
-        else
+
+        sb.Append(" {").AppendLine();
+
+        foreach (var node in Nodes)
         {
-            sb.AppendLine($"{indent}@{Name}{paramsStr} {{");
-
-            foreach (var node in Nodes)
-            {
-                sb.AppendLine(node.ToCss(indentLevel + 1));
-            }
-
-            sb.Append($"{indent}}}");
+            node.WriteCss(sb, indentLevel + 1);
+            sb.AppendLine();
         }
 
-        return sb.ToString();
+        AppendIndent(sb, indentLevel);
+        sb.Append('}');
     }
 }
 
@@ -138,8 +183,15 @@ internal record Comment(string Value) : AstNode
 
     public override string ToCss(int indentLevel = 0)
     {
-        var indent = GetIndent(indentLevel);
-        return $"{indent}/* {Value} */";
+        var sb = new StringBuilder();
+        WriteCss(sb, indentLevel);
+        return sb.ToString();
+    }
+
+    internal override void WriteCss(StringBuilder sb, int indentLevel = 0)
+    {
+        AppendIndent(sb, indentLevel);
+        sb.Append("/* ").Append(Value).Append(" */");
     }
 }
 
@@ -150,18 +202,24 @@ internal record Context(ImmutableDictionary<string, object> Metadata, ImmutableL
     public override string ToCss(int indentLevel = 0)
     {
         var sb = new StringBuilder();
+        WriteCss(sb, indentLevel);
+        return sb.ToString();
+    }
 
-        foreach (var node in Nodes)
+    internal override void WriteCss(StringBuilder sb, int indentLevel = 0)
+    {
+        // Separate children with a newline, no leading or trailing newline. (The old ToCss used a
+        // fresh builder, so its `sb.Length > 0` guard meant "not the first child"; with a shared
+        // buffer we track the index explicitly instead.)
+        for (var i = 0; i < Nodes.Count; i++)
         {
-            if (sb.Length > 0)
+            if (i > 0)
             {
                 sb.AppendLine();
             }
 
-            sb.Append(node.ToCss(indentLevel));
+            Nodes[i].WriteCss(sb, indentLevel);
         }
-
-        return sb.ToString();
     }
 }
 
@@ -171,15 +229,22 @@ internal record RawCss(string Content) : AstNode
 
     public override string ToCss(int indentLevel = 0)
     {
-        var indent = GetIndent(indentLevel);
+        var sb = new StringBuilder();
+        WriteCss(sb, indentLevel);
+        return sb.ToString();
+    }
+
+    internal override void WriteCss(StringBuilder sb, int indentLevel = 0)
+    {
         var lines = Content.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
 
         if (lines.Length == 1)
         {
-            return $"{indent}{Content}";
+            AppendIndent(sb, indentLevel);
+            sb.Append(Content);
+            return;
         }
 
-        var sb = new StringBuilder();
         for (var i = 0; i < lines.Length; i++)
         {
             if (i > 0)
@@ -187,17 +252,13 @@ internal record RawCss(string Content) : AstNode
                 sb.AppendLine();
             }
 
+            // Non-blank lines get indented; blank interior lines are preserved as empty (the
+            // newline above already emitted them) — matching the previous line-by-line behavior.
             if (!string.IsNullOrWhiteSpace(lines[i]))
             {
-                sb.Append($"{indent}{lines[i]}");
-            }
-            else if (i < lines.Length - 1)
-            {
-                // Preserve empty lines except at the end
-                sb.Append(string.Empty);
+                AppendIndent(sb, indentLevel);
+                sb.Append(lines[i]);
             }
         }
-
-        return sb.ToString();
     }
 }

--- a/src/MonorailCss/Css/CssGenerator.cs
+++ b/src/MonorailCss/Css/CssGenerator.cs
@@ -217,7 +217,8 @@ internal sealed class CssGenerator
         sb.AppendLine($"@layer {layerName} {{");
         foreach (var node in nodes)
         {
-            sb.AppendLine(node.ToCss(1));
+            node.WriteCss(sb, 1);
+            sb.AppendLine();
         }
 
         sb.AppendLine("}");

--- a/src/MonorailCss/CssFramework.cs
+++ b/src/MonorailCss/CssFramework.cs
@@ -31,7 +31,33 @@ public class CssFramework
     // only readonly framework-lifetime dependencies; per-call state lives in PipelineContext.
     private readonly Pipeline.Pipeline _pipeline;
     private readonly CssGenerator _generator;
+
+    // Per-token compile memoization. Compiling one class is a pure function of (token, theme):
+    // utilities read only the framework-lifetime, immutable theme and *write* @property
+    // registrations — none read prior registry state (verified across every utility) — so a
+    // token's compiled output is stable for this framework's lifetime. We cache the matched
+    // ProcessedClass (itself immutable) together with the registrations the matching utility
+    // made, and replay those registrations into each call's registry so output is byte-identical
+    // to compiling fresh. This is the dotnet-watch win: when the candidate set changes by a class
+    // or two, the other thousands are served from here instead of re-probing every registered
+    // utility. A null entry memoizes "this token compiles to nothing" so invalid tokens (prose,
+    // typos) aren't re-probed either. Bounded (LRU) because arbitrary values (w-[12px], bg-[#abc])
+    // make the key space unbounded; a real project's distinct class set sits well under the cap.
+    private readonly Merging.LruCache<string, TokenCompilation> _compileCache = new(16384);
+
     private Merging.ClassMerger? _merger;
+
+    // A token's cached compilation outcome:
+    //   ProcessedClass non-null            → it compiled; Registrations holds the @property
+    //                                          declarations the matching utility made.
+    //   ProcessedClass null, Parsed true   → it parsed but matched no utility (an invalid class).
+    //   Parsed false                       → it didn't parse; dropped silently, exactly as the
+    //                                          parse step did before this cache existed.
+    private sealed record TokenCompilation(bool Parsed, ProcessedClass? ProcessedClass, CssPropertyDefinition[] Registrations);
+
+    // Shared singletons for the two non-compiling outcomes so prose/typo tokens cost no allocation.
+    private static readonly TokenCompilation Unparseable = new(false, null, []);
+    private static readonly TokenCompilation ParsedNoMatch = new(true, null, []);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CssFramework"/> class.
@@ -245,62 +271,41 @@ public class CssFramework
         var propertyRegistry = new CssPropertyRegistry();
         var themeTracker = new ThemeUsageTracker(_settings.Theme);
 
-        // Parse the input into candidates
-        var candidates = string.IsNullOrWhiteSpace(classString)
-            ? []
-            : _parser.ParseCandidates(classString).ToHashSet();
-
-        // Process each candidate through the utilities
-        foreach (var candidate in candidates)
+        // Compile each distinct class token, served from the per-token cache when seen before.
+        // Tokens are deduplicated here (identical tokens parse to identical candidates), and the
+        // sorting stage canonicalizes output order later, so token order in is not load-bearing.
+        if (!string.IsNullOrWhiteSpace(classString))
         {
-            if (candidate is StaticUtility staticUtility && UtilityRegistry.StaticUtilitiesLookup.TryGetValue(staticUtility.Root, out var value))
+            var seenTokens = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var token in _parser.ExtractClassTokens(classString))
             {
-                // Roll back any @property registrations if the utility doesn't actually match,
-                // so probing never leaks custom properties into an unrelated class's output.
-                var checkpoint = propertyRegistry.Checkpoint();
-                if (value.TryCompile(candidate, _settings.Theme, propertyRegistry, out var astNodes))
+                if (!seenTokens.Add(token))
                 {
-                    processedClasses.Add(new ProcessedClass(
-                        ClassName: candidate.Raw,
-                        UtilityName: value.GetType().Name,
-                        AstNodes: astNodes!,
-                        Candidate: candidate,
-                        Layer: value.Layer));
+                    continue;
+                }
+
+                var compiled = GetOrCompileToken(token);
+                if (compiled.ProcessedClass is null)
+                {
+                    // Parsed-but-unmatched is an invalid class; unparseable is dropped silently,
+                    // mirroring the pre-cache ParseCandidates behavior (which never yielded it).
+                    if (compiled.Parsed)
+                    {
+                        invalidClasses.Add(token);
+                    }
 
                     continue;
                 }
 
-                propertyRegistry.RollbackTo(checkpoint);
-            }
+                processedClasses.Add(compiled.ProcessedClass);
 
-            var processed = false;
-
-            // Try each registered utility. The loop probes utilities in priority order until one
-            // matches, so a utility that registers @property metadata must only have it persist
-            // when it actually compiles the candidate — otherwise unrelated classes accumulate
-            // stray @property blocks. Checkpoint before each probe and roll back on no match.
-            foreach (var utility in UtilityRegistry.RegisteredUtilities)
-            {
-                var checkpoint = propertyRegistry.Checkpoint();
-                if (!utility.TryCompile(candidate, _settings.Theme, propertyRegistry, out var astNodes))
+                // Replay the @property registrations the matching utility made during its compile.
+                // Register is idempotent (TryAdd), so duplicates across candidates collapse exactly
+                // as they did when every candidate shared one registry in the uncached path.
+                foreach (var definition in compiled.Registrations)
                 {
-                    propertyRegistry.RollbackTo(checkpoint);
-                    continue;
+                    propertyRegistry.Register(definition);
                 }
-
-                processedClasses.Add(new ProcessedClass(
-                    ClassName: candidate.Raw,
-                    UtilityName: utility.GetType().Name,
-                    AstNodes: astNodes!,
-                    Candidate: candidate,
-                    Layer: utility.Layer));
-                processed = true;
-                break;
-            }
-
-            if (!processed)
-            {
-                invalidClasses.Add(candidate.Raw);
             }
         }
 
@@ -369,6 +374,67 @@ public class CssFramework
             ProcessedClasses = [.. processedClasses],
             InvalidClasses = [.. invalidClasses],
         };
+    }
+
+    // Returns the cached compilation for a token, compiling and caching it on a miss. The outcome
+    // (compiled / parsed-no-match / unparseable) is memoized so prose and typos aren't re-probed.
+    private TokenCompilation GetOrCompileToken(string token)
+    {
+        if (_compileCache.TryGetValue(token, out var cached))
+        {
+            return cached;
+        }
+
+        var compiled = CompileToken(token);
+        _compileCache.Set(token, compiled);
+        return compiled;
+    }
+
+    // Parses and compiles a single token against the utilities, in the same order the inline loop
+    // used: static lookup first, then the priority-ordered probe. Each probe compiles into its own
+    // throwaway registry, so a non-matching utility's @property writes are discarded with it and
+    // only the winner's registrations are captured — making the per-probe checkpoint/rollback the
+    // shared-registry path needed unnecessary here.
+    private TokenCompilation CompileToken(string token)
+    {
+        if (!_parser.TryParseCandidate(token, out var candidate))
+        {
+            return Unparseable;
+        }
+
+        if (candidate is StaticUtility staticUtility
+            && UtilityRegistry.StaticUtilitiesLookup.TryGetValue(staticUtility.Root, out var staticUtil))
+        {
+            var registry = new CssPropertyRegistry();
+            if (staticUtil.TryCompile(candidate, _settings.Theme, registry, out var astNodes) && astNodes != null)
+            {
+                return BuildCompiledToken(candidate, staticUtil, astNodes, registry);
+            }
+        }
+
+        foreach (var utility in UtilityRegistry.RegisteredUtilities)
+        {
+            var registry = new CssPropertyRegistry();
+            if (utility.TryCompile(candidate, _settings.Theme, registry, out var astNodes) && astNodes != null)
+            {
+                return BuildCompiledToken(candidate, utility, astNodes, registry);
+            }
+        }
+
+        return ParsedNoMatch;
+
+        static TokenCompilation BuildCompiledToken(Candidate candidate, IUtility utility, ImmutableList<AstNode> astNodes, CssPropertyRegistry registry)
+        {
+            var processed = new ProcessedClass(
+                ClassName: candidate.Raw,
+                UtilityName: utility.GetType().Name,
+                AstNodes: astNodes,
+                Candidate: candidate,
+                Layer: utility.Layer);
+
+            var registrations = registry.Count > 0 ? registry.GetAll().ToArray() : [];
+            return new TokenCompilation(true, processed, registrations);
+        }
     }
 
     /// <summary>

--- a/src/MonorailCss/Parser/CandidateParser.cs
+++ b/src/MonorailCss/Parser/CandidateParser.cs
@@ -37,6 +37,13 @@ internal sealed class CandidateParser
         }
     }
 
+    /// <summary>
+    /// Splits a raw class string into whitespace-separated tokens without parsing them. Used by
+    /// <see cref="CssFramework"/> to drive its per-token compile cache: the token string is the
+    /// cache key, so callers tokenize first and only parse on a cache miss.
+    /// </summary>
+    public string[] ExtractClassTokens(string input) => _tokenExtractor.ExtractClassTokens(input);
+
     public bool TryParseCandidate(string input, [NotNullWhen(true)] out Candidate? candidate)
     {
         candidate = null;

--- a/src/MonorailCss/Pipeline/Stages/DeclarationMergingStage.cs
+++ b/src/MonorailCss/Pipeline/Stages/DeclarationMergingStage.cs
@@ -18,26 +18,78 @@ internal class DeclarationMergingStage : IPipelineStage
 
     public ImmutableList<AstNode> Process(ImmutableList<AstNode> nodes, PipelineContext context)
     {
-        var result = ImmutableList.CreateBuilder<AstNode>();
+        // Fast path: merging is a structural no-op for a rule whose children are already distinct
+        // single declarations (the overwhelmingly common utility shape, e.g. one property per rule).
+        // Rebuild the list only once a node actually changes, so an all-no-op pass returns the input
+        // unchanged — no 3000 throwaway StyleRule records, dictionaries, and immutable lists per call.
+        ImmutableList<AstNode>.Builder? result = null;
 
-        foreach (var node in nodes)
+        for (var i = 0; i < nodes.Count; i++)
         {
+            var node = nodes[i];
+            AstNode replacement;
+
             if (node is StyleRule styleRule)
             {
-                var mergedDeclarations = _merger.ExtractAndMergeDeclarations(styleRule.Nodes, _strategy);
-                result.Add(styleRule with { Nodes = mergedDeclarations });
+                if (!NeedsMerge(styleRule.Nodes))
+                {
+                    replacement = node;
+                }
+                else
+                {
+                    var mergedDeclarations = _merger.ExtractAndMergeDeclarations(styleRule.Nodes, _strategy);
+                    replacement = styleRule with { Nodes = mergedDeclarations };
+                }
             }
             else if (node is AtRule atRule)
             {
                 var processedChildren = Process(atRule.Nodes, context);
-                result.Add(atRule with { Nodes = processedChildren });
+                replacement = ReferenceEquals(processedChildren, atRule.Nodes)
+                    ? node
+                    : atRule with { Nodes = processedChildren };
             }
             else
             {
-                result.Add(node);
+                replacement = node;
+            }
+
+            if (result == null && !ReferenceEquals(replacement, node))
+            {
+                // First change: seed the builder with the unchanged prefix we skipped over.
+                result = ImmutableList.CreateBuilder<AstNode>();
+                for (var j = 0; j < i; j++)
+                {
+                    result.Add(nodes[j]);
+                }
+            }
+
+            result?.Add(replacement);
+        }
+
+        return result?.ToImmutable() ?? nodes;
+    }
+
+    // True when extracting + merging would actually change the rule's children: a repeated property
+    // (LastWins would collapse it) or a non-declaration child (which the merger hoists/reorders).
+    // For the typical handful of distinct declarations this is a zero-allocation O(n^2) scan.
+    private static bool NeedsMerge(ImmutableList<AstNode> nodes)
+    {
+        for (var i = 0; i < nodes.Count; i++)
+        {
+            if (nodes[i] is not Declaration di)
+            {
+                return true;
+            }
+
+            for (var j = 0; j < i; j++)
+            {
+                if (nodes[j] is Declaration dj && string.Equals(dj.Property, di.Property, StringComparison.Ordinal))
+                {
+                    return true;
+                }
             }
         }
 
-        return result.ToImmutable();
+        return false;
     }
 }

--- a/src/MonorailCss/Pipeline/Stages/MediaQueryConsolidationStage.cs
+++ b/src/MonorailCss/Pipeline/Stages/MediaQueryConsolidationStage.cs
@@ -29,52 +29,74 @@ internal class MediaQueryConsolidationStage : IPipelineStage
             return nodes;
         }
 
-        var mediaGroups = new Dictionary<string, List<(int Index, AtRule Rule)>>();
-        var resultMap = new SortedDictionary<int, AstNode>();
+        // Pass 1: group @media rules by normalized query and decide whether any rewrite is needed.
+        // A rewrite is only needed when some query repeats (consolidation) or a non-media at-rule is
+        // present (it gets recursed into). When neither holds — e.g. a flat list of utility rules
+        // with at most one rule per breakpoint — we return the input untouched instead of rebuilding
+        // the whole list through a SortedDictionary.
+        Dictionary<string, List<AtRule>>? mediaGroups = null;
+        var needsRewrite = false;
 
-        // Single pass: group nodes with their original indices
-        for (var i = 0; i < nodes.Count; i++)
+        foreach (var node in nodes)
         {
-            var node = nodes[i];
-
-            if (node is AtRule atRule && atRule.Name == "media")
+            if (node is AtRule { Name: "media" } media)
             {
-                var key = NormalizeMediaQuery(atRule.Params);
-                if (!mediaGroups.TryGetValue(key, out var value))
+                mediaGroups ??= new Dictionary<string, List<AtRule>>(StringComparer.Ordinal);
+                var key = NormalizeMediaQuery(media.Params);
+                if (!mediaGroups.TryGetValue(key, out var list))
                 {
-                    value = [];
-                    mediaGroups[key] = value;
+                    list = [];
+                    mediaGroups[key] = list;
                 }
 
-                value.Add((i, atRule));
+                list.Add(media);
+                if (list.Count > 1)
+                {
+                    needsRewrite = true;
+                }
             }
-            else
+            else if (node is AtRule)
             {
-                // Process non-media nodes (including layers and other at-rules)
-                var processedNode = ProcessNode(node);
-                resultMap[i] = processedNode;
+                // Non-media at-rule (e.g. a nested layer): recurse to consolidate inside it.
+                needsRewrite = true;
             }
         }
 
-        // Add consolidated media queries at first occurrence position
-        foreach (var (_, group) in mediaGroups)
+        if (!needsRewrite)
         {
-            var firstIndex = group[0].Index;
+            return nodes;
+        }
 
-            if (group.Count > 1)
+        // Pass 2: rebuild in original order. A multi-rule media group collapses into one rule emitted
+        // at its first occurrence; later members are skipped. Singles and non-media nodes stay put.
+        HashSet<string>? emitted = null;
+        var result = ImmutableList.CreateBuilder<AstNode>();
+
+        foreach (var node in nodes)
+        {
+            if (node is AtRule { Name: "media" } media)
             {
-                // Consolidate multiple media queries into one
-                var consolidatedRule = ConsolidateMediaRules(group.Select(g => g.Rule), group[0].Rule.Params);
-                resultMap[firstIndex] = consolidatedRule;
+                var key = NormalizeMediaQuery(media.Params);
+                var group = mediaGroups![key];
+                if (group.Count == 1)
+                {
+                    result.Add(media);
+                    continue;
+                }
+
+                emitted ??= new HashSet<string>(StringComparer.Ordinal);
+                if (emitted.Add(key))
+                {
+                    result.Add(ConsolidateMediaRules(group, group[0].Params));
+                }
             }
             else
             {
-                // Single media query, keep as is
-                resultMap[firstIndex] = group[0].Rule;
+                result.Add(ProcessNode(node));
             }
         }
 
-        return resultMap.Values.ToImmutableList();
+        return result.ToImmutable();
     }
 
     /// <summary>

--- a/src/MonorailCss/Pipeline/Stages/PropertyRegistrationStage.cs
+++ b/src/MonorailCss/Pipeline/Stages/PropertyRegistrationStage.cs
@@ -264,7 +264,14 @@ internal partial class PropertyRegistrationStage : IPipelineStage
         }
 
         // Also check the value for any custom properties that might need registration
-        // This handles cases where utilities set up initial values
+        // This handles cases where utilities set up initial values. The regex can only match a
+        // "--tw-" substring, so skip the (allocating) Matches call entirely when the value has
+        // none — the overwhelmingly common case (e.g. `var(--color-red-500)`, `calc(...)`).
+        if (!declaration.Value.Contains("--tw-", StringComparison.Ordinal))
+        {
+            return;
+        }
+
         var matches = TailwindPropertyPatternRegExDefinition().Matches(declaration.Value);
         foreach (Match match in matches)
         {

--- a/tests/MonorailCss.Benchmarks/Program.cs
+++ b/tests/MonorailCss.Benchmarks/Program.cs
@@ -40,10 +40,20 @@ public class GenerationBenchmark
     public void Setup()
     {
         _framework = new CssFramework();
+
+        // Warm the framework once on the large set. Models the dotnet-watch steady state: the
+        // first build has happened, and each subsequent Process re-runs over a set that is
+        // identical (no class change) or differs by a class or two. ProcessLarge measures that
+        // repeated run; with a per-candidate compile cache nearly every candidate is a hit.
+        _framework.Process(SampleData.LargeClasses);
     }
 
     [Benchmark]
     public string Process() => _framework.Process(SampleData.Classes);
+
+    /// <summary>Reprocess a ~3000-class set on an already-warm framework — the watch hot path.</summary>
+    [Benchmark]
+    public string ProcessLarge() => _framework.Process(SampleData.LargeClasses);
 }
 
 /// <summary>
@@ -217,6 +227,82 @@ internal static class SampleData
         "z-0", "z-10", "z-20", "z-30", "z-40", "z-50",
         "cursor-pointer", "cursor-default", "cursor-wait", "cursor-text", "cursor-move",
     ];
+
+    /// <summary>
+    /// A large, deterministic set of ~3000 distinct real utility classes — colors across every
+    /// palette/shade, spacing, sizing, plus a handful of variant-prefixed ones — to mirror a
+    /// real app's class surface in a dotnet-watch loop.
+    /// </summary>
+    public static readonly string[] LargeClasses = BuildLargeClasses();
+
+    private static string[] BuildLargeClasses()
+    {
+        var palettes = new[]
+        {
+            "red", "orange", "amber", "yellow", "lime", "green", "emerald", "teal", "cyan", "sky",
+            "blue", "indigo", "violet", "purple", "fuchsia", "pink", "rose", "slate", "gray", "zinc",
+            "neutral", "stone",
+        };
+        var shades = new[] { "50", "100", "200", "300", "400", "500", "600", "700", "800", "900", "950" };
+        var colorPrefixes = new[]
+        {
+            "bg", "text", "border", "ring", "fill", "stroke", "from", "to", "divide", "outline",
+            "decoration", "accent",
+        };
+        var spacingPrefixes = new[]
+        {
+            "p", "px", "py", "pt", "pb", "pl", "pr", "m", "mx", "my", "mt", "mb", "ml", "mr",
+            "gap", "gap-x", "gap-y", "space-x", "space-y",
+        };
+        var sizes = new[]
+        {
+            "0", "0.5", "1", "1.5", "2", "2.5", "3", "3.5", "4", "5", "6", "7", "8", "9", "10",
+            "11", "12", "14", "16", "20", "24", "28", "32", "40", "48", "56", "64",
+        };
+        var sizingPrefixes = new[] { "w", "h", "min-w", "max-w", "min-h", "max-h" };
+        var variants = new[] { string.Empty, "hover:", "focus:", "md:", "lg:", "dark:" };
+
+        var set = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var prefix in colorPrefixes)
+        {
+            foreach (var palette in palettes)
+            {
+                foreach (var shade in shades)
+                {
+                    set.Add($"{prefix}-{palette}-{shade}");
+                }
+            }
+        }
+
+        foreach (var prefix in spacingPrefixes)
+        {
+            foreach (var size in sizes)
+            {
+                set.Add($"{prefix}-{size}");
+            }
+        }
+
+        foreach (var prefix in sizingPrefixes)
+        {
+            foreach (var size in sizes)
+            {
+                set.Add($"{prefix}-{size}");
+            }
+        }
+
+        foreach (var variant in variants)
+        {
+            set.Add($"{variant}flex");
+            set.Add($"{variant}grid");
+            set.Add($"{variant}hidden");
+            set.Add($"{variant}bg-blue-500");
+            set.Add($"{variant}text-white");
+            set.Add($"{variant}p-4");
+        }
+
+        return set.ToArray();
+    }
 
     private static readonly string[] Prose =
     [


### PR DESCRIPTION
- **perf(framework): cache per-token utility compilation**
- **perf(framework): cut generation allocations and skip no-op pipeline work**
