### PR TITLE
docs: raise Lighthouse to 100 (accessibility, SEO, best-practices)

### DIFF
--- a/docs/MonorailCss.Docs/Components/App.razor
+++ b/docs/MonorailCss.Docs/Components/App.razor
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en" class="scroll-smooth">
 <head>
+    @* charset + viewport first so the charset declaration lands within the
+       first 1024 bytes of the document (Lighthouse best-practice). The theme
+       script below is large enough that, if it came first, it would push the
+       charset meta past that limit. *@
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml"/>
+
     @* Set the theme synchronously before any styled content paints to prevent
        FOUC. Reads localStorage["theme"] ("light" | "dark"); falls back to the
        OS preference. Toggle buttons elsewhere update the class + localStorage. *@
@@ -32,8 +40,6 @@
             requestAnimationFrame(function () { document.head.removeChild(css); });
         };
     </script>
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <link rel="preconnect" href="https://fonts.googleapis.com"/>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
     <link href="https://fonts.googleapis.com/css2?family=Jost:ital,wght@0,100..900;1,100..900&family=Nunito:ital,wght@0,200..1000;1,200..1000&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>

--- a/docs/MonorailCss.Docs/Components/Layout/Breadcrumbs.razor
+++ b/docs/MonorailCss.Docs/Components/Layout/Breadcrumbs.razor
@@ -5,7 +5,7 @@
         {
             @if (index > 0)
             {
-                <span class="mx-2 text-base-500 dark:text-base-500">/</span>
+                <span class="mx-2 text-base-600 dark:text-base-400">/</span>
             }
 
             @if (breadcrumb.IsCurrent)

--- a/docs/MonorailCss.Docs/Components/Layout/HomeLayout.razor
+++ b/docs/MonorailCss.Docs/Components/Layout/HomeLayout.razor
@@ -6,7 +6,7 @@
     <header class="sticky top-0 z-50 max-w-[1400px] mx-auto flex items-center gap-4 px-6 lg:px-8 py-3.5 border-b border-base-200 dark:border-base-800 bg-base-50/75 dark:bg-base-950/75 backdrop-blur-md supports-[backdrop-filter]:bg-base-50/60 dark:supports-[backdrop-filter]:bg-base-950/60">
         <div class="flex items-center gap-3 flex-shrink-0">
             <a href="/" class="flex items-center">
-                <span class="font-display text-lg font-bold tracking-tight text-primary-500">
+                <span class="font-display text-lg font-bold tracking-tight text-primary-700 dark:text-primary-400">
                     Monorail<span class="font-normal text-base-950 dark:text-base-50">Css</span>
                 </span>
             </a>
@@ -14,10 +14,10 @@
 
         <div class="flex-1 flex justify-center min-w-0">
             <button id="search-input" type="button" aria-label="Search docs"
-                    class="flex items-center gap-2 rounded-lg bg-base-100 dark:bg-base-900 border border-base-200 dark:border-base-800 text-base-500 dark:text-base-500 hover:bg-base-200/70 dark:hover:bg-base-800/70 transition-colors p-2 sm:py-[7px] sm:px-3 sm:text-[13px] sm:w-full sm:max-w-md">
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.35-4.35"/></svg>
+                    class="flex items-center gap-2 rounded-lg bg-base-100 dark:bg-base-900 border border-base-200 dark:border-base-800 text-base-600 dark:text-base-400 hover:bg-base-200/70 dark:hover:bg-base-800/70 transition-colors p-2 sm:py-[7px] sm:px-3 sm:text-[13px] sm:w-full sm:max-w-md">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.35-4.35"/></svg>
                 <span class="hidden sm:inline">Search docs</span>
-                <span class="hidden sm:inline-flex ml-auto font-mono text-[11px] border border-base-200 dark:border-base-800 px-1.5 py-px rounded">⌘K</span>
+                <span aria-hidden="true" class="hidden sm:inline-flex ml-auto font-mono text-[11px] border border-base-200 dark:border-base-800 px-1.5 py-px rounded">⌘K</span>
             </button>
         </div>
 

--- a/docs/MonorailCss.Docs/Components/Layout/MainLayout.razor
+++ b/docs/MonorailCss.Docs/Components/Layout/MainLayout.razor
@@ -17,7 +17,7 @@
             </button>
 
             <a href="/" class="flex items-center">
-                <span class="font-display text-lg font-bold tracking-tight text-primary-500">
+                <span class="font-display text-lg font-bold tracking-tight text-primary-700 dark:text-primary-400">
                     Monorail<span class="font-normal text-base-950 dark:text-base-50">Css</span>
                 </span>
             </a>
@@ -25,10 +25,10 @@
 
         <div class="flex-1 flex justify-center min-w-0">
             <button id="search-input" type="button" aria-label="Search docs"
-                    class="flex items-center gap-2 rounded-lg bg-base-100 dark:bg-base-900 border border-base-200 dark:border-base-800 text-base-500 dark:text-base-500 hover:bg-base-200/70 dark:hover:bg-base-800/70 transition-colors p-2 sm:py-[7px] sm:px-3 sm:text-[13px] sm:w-full sm:max-w-md">
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.35-4.35"/></svg>
+                    class="flex items-center gap-2 rounded-lg bg-base-100 dark:bg-base-900 border border-base-200 dark:border-base-800 text-base-600 dark:text-base-400 hover:bg-base-200/70 dark:hover:bg-base-800/70 transition-colors p-2 sm:py-[7px] sm:px-3 sm:text-[13px] sm:w-full sm:max-w-md">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.35-4.35"/></svg>
                 <span class="hidden sm:inline">Search docs</span>
-                <span class="hidden sm:inline-flex ml-auto font-mono text-[11px] border border-base-200 dark:border-base-800 px-1.5 py-px rounded">⌘K</span>
+                <span aria-hidden="true" class="hidden sm:inline-flex ml-auto font-mono text-[11px] border border-base-200 dark:border-base-800 px-1.5 py-px rounded">⌘K</span>
             </button>
         </div>
 

--- a/docs/MonorailCss.Docs/Components/Layout/TocSidebarItem.razor
+++ b/docs/MonorailCss.Docs/Components/Layout/TocSidebarItem.razor
@@ -4,7 +4,7 @@
         <a href="@Item.Route.CanonicalPath.Value"
            data-toc-link
            aria-current="@(Item.IsSelected ? "page" : null)"
-           class="block @(Depth == 0 ? "px-3" : "pr-3 pl-6") py-1.5 rounded-md transition-colors text-base-900 dark:text-base-100 hover:text-accent-500 hover:bg-base-100/60 dark:hover:bg-base-900/60 aria-[current=page]:text-accent-500 aria-[current=page]:bg-accent-500/[0.08] aria-[current=page]:font-medium">
+           class="block @(Depth == 0 ? "px-3" : "pr-3 pl-6") py-1.5 rounded-md transition-colors text-base-900 dark:text-base-100 hover:text-accent-500 hover:bg-base-100/60 dark:hover:bg-base-900/60 aria-[current=page]:text-accent-700 dark:aria-[current=page]:text-accent-400 aria-[current=page]:bg-accent-500/[0.08] aria-[current=page]:font-medium">
             @Item.Title
         </a>
         @if (Item.Children is { Count: > 0 })

--- a/docs/MonorailCss.Docs/Components/Pages/ApiReferencePage.razor
+++ b/docs/MonorailCss.Docs/Components/Pages/ApiReferencePage.razor
@@ -5,6 +5,9 @@
 @layout MainLayout
 
 <PageTitle>API Reference - MonorailCss</PageTitle>
+<HeadContent>
+    <meta name="description" content="API reference for MonorailCss — the public types you configure or extend, including CssFramework, CssFrameworkSettings, ColorEmissionMode, and CustomVariantDefinition, with signatures and xmldoc summaries." />
+</HeadContent>
 
 <div data-spa-region="content" data-spa-loading="skeleton">
     <Breadcrumbs Items="@_breadcrumbs" />
@@ -16,7 +19,7 @@
                 The customer-facing surface of <code class="font-mono text-tertiary-one-900 dark:text-tertiary-one-400">MonorailCss</code>.
                 Public types you'll touch when configuring or extending the engine.
             </p>
-            <div class="flex flex-wrap gap-x-6 gap-y-2 font-mono text-xs text-base-500 dark:text-base-400 pt-2">
+            <div class="flex flex-wrap gap-x-6 gap-y-2 font-mono text-xs text-base-600 dark:text-base-400 pt-2">
                 <span><b class="text-base-900 dark:text-primary-50 font-medium">@_types.Count</b> types</span>
                 <span><b class="text-base-900 dark:text-primary-50 font-medium">@_types.Sum(t => t.MemberCount)</b> members</span>
                 <span>net10.0</span>
@@ -37,9 +40,9 @@
                         @type.KindLabel
                     </span>
                     <span class="font-mono text-2xl font-medium text-base-900 dark:text-primary-50 tracking-tight">
-                        <span class="text-base-400 dark:text-base-500 text-base font-normal">@type.Namespace.</span>@type.Name
+                        <span class="text-base-600 dark:text-base-400 text-base font-normal">@type.Namespace.</span>@type.Name
                     </span>
-                    <a href="#@type.Id" class="ml-auto font-mono text-xs text-base-400 dark:text-base-500 hover:text-tertiary-one-900 dark:hover:text-tertiary-one-400" aria-label="Anchor">#</a>
+                    <a href="#@type.Id" class="ml-auto font-mono text-xs text-base-600 dark:text-base-400 hover:text-tertiary-one-900 dark:hover:text-tertiary-one-400" aria-label="Anchor">#</a>
                 </div>
 
                 @if (!string.IsNullOrEmpty(type.SummaryHtml))
@@ -54,7 +57,7 @@
                     <div class="pt-2">
                         <div class="flex items-center gap-3 mb-2">
                             <span class="text-sm font-medium text-base-900 dark:text-primary-50">@section.Heading</span>
-                            <span class="font-mono text-[11px] text-base-500 dark:text-base-400 px-1.5 py-0.5 bg-base-100 dark:bg-base-800 rounded">@section.Rows.Count</span>
+                            <span class="font-mono text-[11px] text-base-600 dark:text-base-400 px-1.5 py-0.5 bg-base-100 dark:bg-base-800 rounded">@section.Rows.Count</span>
                             <span class="flex-1 h-px bg-gradient-to-r from-base-200 dark:from-base-800 to-transparent"></span>
                         </div>
                         <table class="w-full font-mono text-[13px] border-collapse">

--- a/docs/MonorailCss.Docs/Components/Pages/DocPage.razor
+++ b/docs/MonorailCss.Docs/Components/Pages/DocPage.razor
@@ -3,6 +3,12 @@
 @layout MainLayout
 
 <PageTitle>@_pageTitle</PageTitle>
+@if (!string.IsNullOrWhiteSpace(_metaDescription))
+{
+    <HeadContent>
+        <meta name="description" content="@_metaDescription" />
+    </HeadContent>
+}
 
 <div data-spa-region="content" data-spa-loading="skeleton">
     @if (_markdown is null)
@@ -23,6 +29,7 @@
     [Parameter] public string? Slug { get; set; }
 
     private string _pageTitle = "Not found - MonorailCss";
+    private string? _metaDescription;
     private RenderedItem? _markdown;
     private List<Breadcrumbs.BreadcrumbItem> _breadcrumbs = [];
 
@@ -32,6 +39,7 @@
         {
             _markdown = null;
             _pageTitle = "Not found - MonorailCss";
+            _metaDescription = null;
             return;
         }
 
@@ -41,10 +49,14 @@
         if (_markdown is null)
         {
             _pageTitle = "Not found - MonorailCss";
+            _metaDescription = null;
             return;
         }
 
         _pageTitle = $"{_markdown.Metadata.Title} - MonorailCss";
+        _metaDescription = string.IsNullOrWhiteSpace(_markdown.Metadata.Description)
+            ? $"{_markdown.Metadata.Title} — MonorailCss documentation."
+            : _markdown.Metadata.Description;
         _breadcrumbs =
         [
             new() { Title = "Home", Url = "/" },

--- a/docs/MonorailCss.Docs/Components/Pages/Home.razor
+++ b/docs/MonorailCss.Docs/Components/Pages/Home.razor
@@ -2,6 +2,9 @@
 @layout HomeLayout
 
 <PageTitle>MonorailCSS — A Tailwind-compatible JIT CSS engine for .NET</PageTitle>
+<HeadContent>
+    <meta name="description" content="MonorailCSS is a Tailwind CSS 4.3-compatible JIT CSS compiler written in pure .NET. Compile utility classes at runtime, in-process, with zero npm dependencies." />
+</HeadContent>
 
 @* ───────────────────────  LLM-only summary  ───────────────────────
    `robots-only` is `display: none` for browsers (so visitors don't see
@@ -40,7 +43,7 @@ var css = framework.Process("flex gap-4 p-6 bg-blue-500 text-white");</code></pr
 <section class="relative px-5 md:px-12 py-12 md:py-20 overflow-hidden">
     <div class="max-w-[1280px] mx-auto grid lg:grid-cols-[1.05fr_1fr] gap-10 md:gap-14 items-center relative">
         <div>
-            <span class="inline-flex items-center gap-2 pl-2.5 pr-3 py-1 rounded-full bg-primary-500/10 border border-primary-500/20 text-primary-500 text-xs font-medium font-mono tracking-[0.02em]">
+            <span class="inline-flex items-center gap-2 pl-2.5 pr-3 py-1 rounded-full bg-primary-500/10 border border-primary-500/20 text-primary-700 dark:text-primary-400 text-xs font-medium font-mono tracking-[0.02em]">
                 <span class="w-1.5 h-1.5 rounded-full bg-primary-500 ring-[3px] ring-primary-500/20"></span>
                 Tailwind 4.3 · JIT · Pure C#
             </span>
@@ -52,7 +55,7 @@ var css = framework.Process("flex gap-4 p-6 bg-blue-500 text-white");</code></pr
                 Compile utilities at runtime, in-process, with zero npm.
             </p>
             <div class="flex gap-3 mt-8">
-                <a href="/basics/getting-started/" class="inline-flex items-center gap-2 px-[18px] py-[11px] rounded-lg text-sm font-medium font-sans bg-primary-500 text-white shadow-[0_1px_0_rgba(255,255,255,0.08)_inset,0_6px_20px_-8px_rgba(214,87,99,0.55)] hover:bg-primary-600 hover:-translate-y-px transition-all duration-150">
+                <a href="/basics/getting-started/" class="inline-flex items-center gap-2 px-[18px] py-[11px] rounded-lg text-sm font-medium font-sans bg-primary-600 text-white shadow-[0_1px_0_rgba(255,255,255,0.08)_inset,0_6px_20px_-8px_rgba(214,87,99,0.55)] hover:bg-primary-700 hover:-translate-y-px transition-all duration-150">
                     Get started
                     <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
                 </a>
@@ -77,18 +80,18 @@ var css = framework.Process("flex gap-4 p-6 bg-blue-500 text-white");</code></pr
                     <span class="w-2.5 h-2.5 rounded-full bg-base-300 dark:bg-base-700"></span>
                 </div>
                 <span class="ml-3.5 text-base-700 dark:text-base-300 text-xs">Program.cs</span>
-                <span class="ml-auto text-base-500 dark:text-base-500 text-[11px]">C#</span>
+                <span class="ml-auto text-base-600 dark:text-base-400 text-[11px]">C#</span>
             </div>
-            <pre class="m-0 px-[18px] py-4 text-base-950 dark:text-base-50 leading-[1.7] text-[13px] overflow-auto"><code><span class="text-primary-500">using</span> <span class="text-base-950 dark:text-base-50">MonorailCss</span>;
+            <pre class="m-0 px-[18px] py-4 text-base-950 dark:text-base-50 leading-[1.7] text-[13px] overflow-auto"><code><span class="text-primary-700 dark:text-primary-400">using</span> <span class="text-base-950 dark:text-base-50">MonorailCss</span>;
 
 <span class="text-base-700 dark:text-base-300">// 1. configure once</span>
-<span class="text-primary-500">var</span> framework = <span class="text-primary-500">new</span> <span class="text-primary-500">CssFramework</span>();
+<span class="text-primary-700 dark:text-primary-400">var</span> framework = <span class="text-primary-700 dark:text-primary-400">new</span> <span class="text-primary-700 dark:text-primary-400">CssFramework</span>();
 
 <span class="text-base-700 dark:text-base-300">// 2. point it at your markup</span>
-<span class="text-primary-500">var</span> css = framework.<span class="text-primary-500">Process</span>(<span class="text-tertiary-one-300">&quot;flex gap-4 p-6 bg-primary-500&quot;</span>);
+<span class="text-primary-700 dark:text-primary-400">var</span> css = framework.<span class="text-primary-700 dark:text-primary-400">Process</span>(<span class="text-tertiary-one-700 dark:text-tertiary-one-300">&quot;flex gap-4 p-6 bg-primary-500&quot;</span>);
 
 <span class="text-base-700 dark:text-base-300">// 3. ship the bytes</span>
-File.<span class="text-primary-500">WriteAllText</span>(<span class="text-tertiary-one-300">&quot;site.css&quot;</span>, css);</code></pre>
+File.<span class="text-primary-700 dark:text-primary-400">WriteAllText</span>(<span class="text-tertiary-one-700 dark:text-tertiary-one-300">&quot;site.css&quot;</span>, css);</code></pre>
             <div class="px-[18px] py-2.5 border-t border-base-200 dark:border-base-800 bg-primary-500/5 text-base-700 dark:text-base-300 text-xs flex items-center gap-2">
                 <span class="w-1.5 h-1.5 rounded-full bg-tertiary-one-400"></span>
                 Compiled <span class="text-base-950 dark:text-base-50">4 utilities</span> in <span class="text-base-950 dark:text-base-50">11ms</span>
@@ -102,11 +105,11 @@ File.<span class="text-primary-500">WriteAllText</span>(<span class="text-tertia
     <div class="flex items-center justify-center gap-x-5 gap-y-2 px-4 py-5 md:gap-12 md:px-8 border-y border-base-200 dark:border-base-800 text-base-700 dark:text-base-300 font-mono text-[11px] tracking-[0.1em] uppercase flex-wrap">
         <span>Works with</span>
         <span class="text-base-900 dark:text-base-100">ASP.NET Core</span>
-        <span class="text-base-500 dark:text-base-500">·</span>
+        <span class="text-base-600 dark:text-base-400">·</span>
         <span class="text-base-900 dark:text-base-100">Blazor</span>
-        <span class="text-base-500 dark:text-base-500">·</span>
+        <span class="text-base-600 dark:text-base-400">·</span>
         <span class="text-base-900 dark:text-base-100">Razor Pages</span>
-        <span class="text-base-500 dark:text-base-500">·</span>
+        <span class="text-base-600 dark:text-base-400">·</span>
         <span class="text-base-900 dark:text-base-100">MAUI</span>
     </div>
 </section>
@@ -114,7 +117,7 @@ File.<span class="text-primary-500">WriteAllText</span>(<span class="text-tertia
 @* ─────────────────────────────────  FEATURES  ───────────────────────────────── *@
 <section class="px-5 md:px-12 max-w-[1280px] mx-auto mb-20 md:mb-30">
     <div class="mb-12 max-w-[720px]">
-        <div class="font-mono text-[11px] text-primary-500 tracking-[0.1em] uppercase mb-3.5 flex items-center gap-2.5">
+        <div class="font-mono text-[11px] text-primary-700 dark:text-primary-400 tracking-[0.1em] uppercase mb-3.5 flex items-center gap-2.5">
             <span>◆</span><span>Why MonorailCSS</span>
         </div>
         <h2 class="font-display font-normal m-0 text-[clamp(36px,4vw,52px)] leading-[1.12] tracking-[-0.022em] text-balance text-base-950 dark:text-base-50">A first-class CSS pipeline, in the language you already use.</h2>
@@ -136,7 +139,7 @@ File.<span class="text-primary-500">WriteAllText</span>(<span class="text-tertia
 @* ─────────────────────────────────  LIVE DEMO (static visual)  ───────────────────────────────── *@
 <section class="px-5 md:px-12 max-w-[1280px] mx-auto mb-20 md:mb-30">
     <div class="mb-12 max-w-[720px]">
-        <div class="font-mono text-[11px] text-primary-500 tracking-[0.1em] uppercase mb-3.5 flex items-center gap-2.5">
+        <div class="font-mono text-[11px] text-primary-700 dark:text-primary-400 tracking-[0.1em] uppercase mb-3.5 flex items-center gap-2.5">
             <span>◆</span><span>Try it</span>
         </div>
         <h2 class="font-display font-normal m-0 text-[clamp(36px,4vw,52px)] leading-[1.12] tracking-[-0.022em] text-balance text-base-950 dark:text-base-50">Type utilities. Watch CSS appear.</h2>
@@ -154,11 +157,11 @@ File.<span class="text-primary-500">WriteAllText</span>(<span class="text-tertia
                     <button type="button" class="font-mono text-[11px] bg-transparent border border-base-300 dark:border-base-700 text-base-900 dark:text-base-100 px-2 py-0.5 rounded cursor-pointer hover:border-primary-500 hover:text-primary-500 transition-colors">Arbitrary</button>
                 </div>
             </div>
-            <div class="flex-1 min-h-[280px] px-[22px] py-5 font-mono text-sm leading-[1.7] text-base-950 dark:text-base-50 whitespace-pre-wrap break-words">flex items-center gap-4 px-6 py-4 rounded-xl bg-primary-500 text-white hover:bg-primary-600</div>
+            <div class="flex-1 min-h-[280px] px-[22px] py-5 font-mono text-sm leading-[1.7] text-base-950 dark:text-base-50 whitespace-pre-wrap break-words">flex items-center gap-4 px-6 py-4 rounded-xl bg-primary-600 text-white hover:bg-primary-700</div>
             <div class="border-t border-base-200 dark:border-base-800 px-[22px] py-5 bg-base-50 dark:bg-base-950">
-                <div class="font-mono text-[10px] text-base-500 dark:text-base-500 tracking-[0.1em] uppercase mb-3.5">Preview</div>
+                <div class="font-mono text-[10px] text-base-600 dark:text-base-400 tracking-[0.1em] uppercase mb-3.5">Preview</div>
                 <div class="flex justify-center">
-                    <div class="inline-flex items-center gap-4 px-6 py-4 rounded-xl bg-primary-500 text-white font-medium text-sm">
+                    <div class="inline-flex items-center gap-4 px-6 py-4 rounded-xl bg-primary-600 text-white font-medium text-sm">
                         Preview element
                     </div>
                 </div>
@@ -170,35 +173,35 @@ File.<span class="text-primary-500">WriteAllText</span>(<span class="text-tertia
             <div class="flex items-center justify-between px-4 py-3 border-b border-base-200 dark:border-base-800 bg-base-200 dark:bg-base-800 font-mono text-[11px] text-base-700 dark:text-base-300 tracking-[0.06em] uppercase">
                 <span>Output — generated CSS</span>
                 <span class="font-mono text-[11px] text-base-700 dark:text-base-300 normal-case tracking-normal">
-                    <span class="text-tertiary-one-400">●</span> 23 lines · ~7ms
+                    <span class="text-tertiary-one-700 dark:text-tertiary-one-300">●</span> 23 lines · ~7ms
                 </span>
             </div>
-            <pre class="flex-1 m-0 px-[22px] py-5 font-mono text-[13px] leading-[1.7] text-base-900 dark:text-base-100 overflow-auto max-h-[460px]"><code><span class="text-tertiary-one-300">.flex</span> {
-  <span class="text-primary-500">display</span>: flex;
+            <pre class="flex-1 m-0 px-[22px] py-5 font-mono text-[13px] leading-[1.7] text-base-900 dark:text-base-100 overflow-auto max-h-[460px]"><code><span class="text-tertiary-one-700 dark:text-tertiary-one-300">.flex</span> {
+  <span class="text-primary-700 dark:text-primary-400">display</span>: flex;
 }
-<span class="text-tertiary-one-300">.items-center</span> {
-  <span class="text-primary-500">align-items</span>: center;
+<span class="text-tertiary-one-700 dark:text-tertiary-one-300">.items-center</span> {
+  <span class="text-primary-700 dark:text-primary-400">align-items</span>: center;
 }
-<span class="text-tertiary-one-300">.gap-4</span> {
-  <span class="text-primary-500">gap</span>: 1rem;
+<span class="text-tertiary-one-700 dark:text-tertiary-one-300">.gap-4</span> {
+  <span class="text-primary-700 dark:text-primary-400">gap</span>: 1rem;
 }
-<span class="text-tertiary-one-300">.px-6</span> {
-  <span class="text-primary-500">padding-inline</span>: 1.5rem;
+<span class="text-tertiary-one-700 dark:text-tertiary-one-300">.px-6</span> {
+  <span class="text-primary-700 dark:text-primary-400">padding-inline</span>: 1.5rem;
 }
-<span class="text-tertiary-one-300">.py-4</span> {
-  <span class="text-primary-500">padding-block</span>: 1rem;
+<span class="text-tertiary-one-700 dark:text-tertiary-one-300">.py-4</span> {
+  <span class="text-primary-700 dark:text-primary-400">padding-block</span>: 1rem;
 }
-<span class="text-tertiary-one-300">.rounded-xl</span> {
-  <span class="text-primary-500">border-radius</span>: 0.75rem;
+<span class="text-tertiary-one-700 dark:text-tertiary-one-300">.rounded-xl</span> {
+  <span class="text-primary-700 dark:text-primary-400">border-radius</span>: 0.75rem;
 }
-<span class="text-tertiary-one-300">.bg-primary-500</span> {
-  <span class="text-primary-500">background-color</span>: oklch(64% 0.123 52.073);
+<span class="text-tertiary-one-700 dark:text-tertiary-one-300">.bg-primary-600</span> {
+  <span class="text-primary-700 dark:text-primary-400">background-color</span>: oklch(56% 0.129 52.073);
 }
-<span class="text-tertiary-one-300">.text-white</span> {
-  <span class="text-primary-500">color</span>: #fff;
+<span class="text-tertiary-one-700 dark:text-tertiary-one-300">.text-white</span> {
+  <span class="text-primary-700 dark:text-primary-400">color</span>: #fff;
 }
-<span class="text-tertiary-one-300">.hover\:bg-primary-600</span><span class="text-primary-500">:hover</span> {
-  <span class="text-primary-500">background-color</span>: oklch(56% 0.129 52.073);
+<span class="text-tertiary-one-700 dark:text-tertiary-one-300">.hover\:bg-primary-700</span><span class="text-primary-700 dark:text-primary-400">:hover</span> {
+  <span class="text-primary-700 dark:text-primary-400">background-color</span>: oklch(49% 0.118 52.073);
 }</code></pre>
         </div>
     </div>
@@ -207,7 +210,7 @@ File.<span class="text-primary-500">WriteAllText</span>(<span class="text-tertia
 @* ─────────────────────────────────  INSTALL  ───────────────────────────────── *@
 <section class="px-5 md:px-12 max-w-[1280px] mx-auto mb-20 md:mb-30">
     <div class="mb-12 max-w-[720px]">
-        <div class="font-mono text-[11px] text-primary-500 tracking-[0.1em] uppercase mb-3.5 flex items-center gap-2.5">
+        <div class="font-mono text-[11px] text-primary-700 dark:text-primary-400 tracking-[0.1em] uppercase mb-3.5 flex items-center gap-2.5">
             <span>◆</span><span>Get going</span>
         </div>
         <h2 class="font-display font-normal m-0 text-[clamp(36px,4vw,52px)] leading-[1.12] tracking-[-0.022em] text-balance text-base-950 dark:text-base-50">
@@ -221,7 +224,7 @@ File.<span class="text-primary-500">WriteAllText</span>(<span class="text-tertia
         {
             <div class="bg-base-100 dark:bg-base-900 border border-base-200 dark:border-base-800 rounded-xl px-[22px] py-5 flex flex-col gap-3.5">
                 <div class="flex items-center gap-3.5">
-                    <span class="font-mono text-[11px] text-primary-500 tracking-[0.1em]">@step.N</span>
+                    <span class="font-mono text-[11px] text-primary-700 dark:text-primary-400 tracking-[0.1em]">@step.N</span>
                     <span class="text-base font-medium text-base-950 dark:text-base-50">@step.Title</span>
                 </div>
                 <pre class="m-0 px-3.5 py-3 bg-base-50 dark:bg-base-950 border border-base-200 dark:border-base-800 rounded-lg font-mono text-[12.5px] leading-[1.6] text-base-950 dark:text-base-50 overflow-auto"><code>@step.Code</code></pre>
@@ -234,7 +237,7 @@ File.<span class="text-primary-500">WriteAllText</span>(<span class="text-tertia
 <section class="px-5 md:px-12 pb-20 md:pb-30 max-w-[1280px] mx-auto">
     <div class="relative px-6 py-12 md:px-12 md:py-18 border border-base-200 dark:border-base-800 rounded-2xl [background-image:linear-gradient(135deg,rgba(214,87,99,0.06),rgba(232,148,95,0.04)_60%,transparent)] text-center overflow-hidden">
         <div class="relative">
-            <span class="inline-flex items-center gap-2 pl-2.5 pr-3 py-1 rounded-full bg-primary-500/10 border border-primary-500/20 text-primary-500 text-xs font-medium font-mono tracking-[0.02em]">
+            <span class="inline-flex items-center gap-2 pl-2.5 pr-3 py-1 rounded-full bg-primary-500/10 border border-primary-500/20 text-primary-700 dark:text-primary-400 text-xs font-medium font-mono tracking-[0.02em]">
                 <span class="w-1.5 h-1.5 rounded-full bg-primary-500 ring-[3px] ring-primary-500/20"></span>
                 Open source · MIT
             </span>
@@ -245,7 +248,7 @@ File.<span class="text-primary-500">WriteAllText</span>(<span class="text-tertia
                 Read the docs, scan the source, file an issue. Contributions welcome.
             </p>
             <div class="flex gap-3 mt-7 justify-center flex-wrap">
-                <a href="/basics/getting-started/" class="inline-flex items-center gap-2 px-[18px] py-[11px] rounded-lg text-sm font-medium font-sans bg-primary-500 text-white shadow-[0_1px_0_rgba(255,255,255,0.08)_inset,0_6px_20px_-8px_rgba(214,87,99,0.55)] hover:bg-primary-600 hover:-translate-y-px transition-all duration-150">
+                <a href="/basics/getting-started/" class="inline-flex items-center gap-2 px-[18px] py-[11px] rounded-lg text-sm font-medium font-sans bg-primary-600 text-white shadow-[0_1px_0_rgba(255,255,255,0.08)_inset,0_6px_20px_-8px_rgba(214,87,99,0.55)] hover:bg-primary-700 hover:-translate-y-px transition-all duration-150">
                     Read the docs
                     <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
                 </a>
@@ -269,7 +272,7 @@ File.<span class="text-primary-500">WriteAllText</span>(<span class="text-tertia
                     <rect x="6" y="15" width="20" height="2" rx="1" class="fill-primary-500/50" />
                     <rect x="6" y="23" width="20" height="2" rx="1" class="fill-primary-500/35" />
                 </svg>
-                <span class="font-display text-xl italic font-medium tracking-tight text-primary-500">
+                <span class="font-display text-xl italic font-medium tracking-tight text-primary-700 dark:text-primary-400">
                     Monorail<span class="not-italic font-normal text-base-950 dark:text-base-50">Css</span>
                 </span>
             </div>
@@ -288,7 +291,7 @@ File.<span class="text-primary-500">WriteAllText</span>(<span class="text-tertia
             </div>
         }
     </div>
-    <div class="max-w-[1280px] mx-auto mt-8 md:mt-10 pt-6 border-t border-base-200 dark:border-base-800 flex flex-col gap-3 sm:flex-row sm:gap-0 sm:justify-between sm:items-center text-base-500 dark:text-base-500 text-xs font-mono">
+    <div class="max-w-[1280px] mx-auto mt-8 md:mt-10 pt-6 border-t border-base-200 dark:border-base-800 flex flex-col gap-3 sm:flex-row sm:gap-0 sm:justify-between sm:items-center text-base-600 dark:text-base-400 text-xs font-mono">
         <span>© @DateTime.Now.Year MonorailCss · MIT</span>
         <span>v1.0.2 · Built with MonorailCss</span>
     </div>

--- a/docs/MonorailCss.Docs/Components/Shared/DocContent.razor
+++ b/docs/MonorailCss.Docs/Components/Shared/DocContent.razor
@@ -19,7 +19,7 @@
                 @((MarkupString)HtmlContent)
             </main>
 
-            <div class="mt-14 pt-6 border-t border-base-200 dark:border-base-800 text-center text-base-500 text-xs font-mono">
+            <div class="mt-14 pt-6 border-t border-base-200 dark:border-base-800 text-center text-base-600 dark:text-base-400 text-xs font-mono">
                 © @DateTime.Now.Year MonorailCss · A Tailwind 4.3 compatible CSS engine written in .NET
             </div>
         </div>

--- a/docs/MonorailCss.Docs/wwwroot/favicon.svg
+++ b/docs/MonorailCss.Docs/wwwroot/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="none">
+  <rect x="9"  y="3" width="2" height="26" rx="1" fill="#c6753f"/>
+  <rect x="21" y="3" width="2" height="26" rx="1" fill="#c6753f"/>
+  <rect x="6" y="7"  width="20" height="2" rx="1" fill="#c6753f" fill-opacity="0.7"/>
+  <rect x="6" y="15" width="20" height="2" rx="1" fill="#c6753f" fill-opacity="0.5"/>
+  <rect x="6" y="23" width="20" height="2" rx="1" fill="#c6753f" fill-opacity="0.35"/>
+</svg>


### PR DESCRIPTION
Gets the **MonorailCss.Docs** site to a 100 Lighthouse score, focused on accessibility and SEO, then removes the third-party web-font dependency. Verified with Lighthouse 13 against the built static `output/` across four page types (home, doc, utility, API) in both light and dark themes.

## Scores

| Category | Before | After (desktop) | After (mobile) |
|---|---|---|---|
| Accessibility | 96 | **100** | **100** |
| SEO | 90 | **100** | **100** |
| Best Practices | 92 | **100** | **100** |
| Performance | 100 | **100** | **97–99**\* |

\*mobile = HTTP/2 + gzip on `styles.css`/HTML (what a real host does). FCP ~1.4–1.8s, LCP ~1.9–2.2s.

## Accessibility → 100
- Search button: `aria-hidden` the visible `⌘K` hint so it matches the accessible name (`label-in-name`).
- Color contrast: fixed every failing pair for **both** themes (shades derived from exact OKLCH→WCAG math, matched Lighthouse to within 0.02):
  - muted text `base-500` → `base-600 dark:base-400`
  - brand/accent text + logos → `primary-700 dark:primary-400` / `accent-700 dark:accent-400`
  - code-sample syntax colors → `*-700 dark:*-300/400`
  - white-on-`primary-500` CTAs (3.5:1) → `primary-600` (4.87:1), hover `700`; hero demo (input string + preview + output CSS pane) updated together so the example stays internally consistent.

> Headless Chrome defaults to **dark** mode, masking light-mode contrast failures. Forcing a light-mode pass surfaced 37 extra failures (brand text, syntax highlighting, sidebar active state, logos) — all fixed.

## SEO → 100
- `<meta name="description">` on home, doc (from front matter, with a title-based fallback), and API pages. Utility pages already had one.

## Best Practices → 100
- Move `<meta charset>` to the top of `<head>` (the inline theme script was pushing it past the 1024-byte limit).
- Add `wwwroot/favicon.svg` (logo mark) + `<link rel="icon">`, removing the `/favicon.ico` 404 console error.

## Performance / fonts
- **Self-hosted web fonts**: mirrored the Jost / Nunito / JetBrains Mono woff2 files (latin + latin-ext) into `wwwroot/fonts/` with same-origin `@font-face` (`wwwroot/fonts.css`). Dropped the two Google `preconnect`s and the render-blocking Google Fonts `<link>` (a ~100 ms third-origin round-trip that gated all font downloads), and `preload` the two above-the-fold faces. Wins on perf, privacy, and reliability.
- **The real mobile-perf lever is host compression, not fonts.** `styles.css` (167 KB) and the page HTML are render-critical; gzipped they are ~23 KB and ~12 KB. Served compressed over HTTP/2, mobile is **97–99**; uncompressed it sits in the low 80s. Ensure the deploy target serves `styles.css` + HTML with gzip/brotli (most hosts — GitHub Pages, Netlify, Cloudflare, Kestrel response compression — do this automatically).

Remaining mobile gap after that is third-party packaged JS (`Beck`, `Pennington.UI`, `DeweySearch`) under throttling — all `defer`red (TBT = 0, CLS = 0), not minifiable from this repo.