### PR TITLE
fix: reject scanner-noise candidates that emit stylesheet-breaking CSS

### DIFF
--- a/src/MonorailCss.Discovery/ClassDiscoveryService.cs
+++ b/src/MonorailCss.Discovery/ClassDiscoveryService.cs
@@ -783,6 +783,15 @@ internal sealed partial class ClassDiscoveryService : IHostedService, IClassRegi
                 continue;
             }
 
+            // _framework/ carries the .NET runtime and Blazor boot bundles (dotnet.runtime.*.js,
+            // blazor.web.js, …) — minified compiler artifacts, not author-written markup. Their
+            // regex literals tokenize as class-shaped noise (e.g. `[(?<funcNum>\d+)\]:0x[a-fA-F\d]`
+            // parses as an arbitrary property), so skip them unconditionally.
+            if (asset.UrlPath.StartsWith("_framework/", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
             if (seen.Add(asset.PhysicalPath) && File.Exists(asset.PhysicalPath))
             {
                 result.Add(asset.PhysicalPath);

--- a/src/MonorailCss/Parser/ArbitraryValueParser.cs
+++ b/src/MonorailCss/Parser/ArbitraryValueParser.cs
@@ -55,6 +55,18 @@ internal partial class ArbitraryValueParser
             };
         }
 
+        // Unbalanced parens/brackets can't be valid CSS component values, and once emitted the
+        // stray opener makes the browser consume every following rule while it hunts for the
+        // matching closer — one bad candidate silently disables the rest of the stylesheet.
+        if (!AreBracketsBalanced(value))
+        {
+            return new ParsedArbitraryValue
+            {
+                IsValid = false,
+                ErrorMessage = "Arbitrary value has unbalanced parentheses or brackets",
+            };
+        }
+
         // Check for data type hint: [color:var(--value)] or [length:100px]
         var dataTypeMatch = DataTypeHintPattern().Match(value);
         if (dataTypeMatch.Success)
@@ -441,6 +453,66 @@ internal partial class ArbitraryValueParser
         // Preserve underscores in the theme path (first argument)
         processed = ProcessFunctionWithPreservedFirstArg(value);
         return true;
+    }
+
+    /// <summary>
+    /// Tests whether every <c>(</c>/<c>)</c> and <c>[</c>/<c>]</c> outside string literals pairs
+    /// up. Grid line names (<c>[full-start]</c>) and functions keep brackets legitimate inside
+    /// arbitrary values; a stray opener or closer means the candidate is not CSS.
+    /// </summary>
+    private bool AreBracketsBalanced(string value)
+    {
+        var parenDepth = 0;
+        var bracketDepth = 0;
+        var inString = false;
+        char? stringChar = null;
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            var ch = value[i];
+
+            if (ch is '"' or '\'' && (i == 0 || value[i - 1] != '\\'))
+            {
+                if (!inString)
+                {
+                    inString = true;
+                    stringChar = ch;
+                }
+                else if (ch == stringChar)
+                {
+                    inString = false;
+                    stringChar = null;
+                }
+            }
+
+            if (inString)
+            {
+                continue;
+            }
+
+            switch (ch)
+            {
+                case '(':
+                    parenDepth++;
+                    break;
+                case ')':
+                    parenDepth--;
+                    break;
+                case '[':
+                    bracketDepth++;
+                    break;
+                case ']':
+                    bracketDepth--;
+                    break;
+            }
+
+            if (parenDepth < 0 || bracketDepth < 0)
+            {
+                return false;
+            }
+        }
+
+        return parenDepth == 0 && bracketDepth == 0;
     }
 
     private bool AreParenthesesBalanced(string value)

--- a/src/MonorailCss/Parser/UtilityMatcher.cs
+++ b/src/MonorailCss/Parser/UtilityMatcher.cs
@@ -182,6 +182,15 @@ internal sealed class UtilityMatcher
             return false;
         }
 
+        // The property must be a CSS identifier (standard, vendor-prefixed, or --custom).
+        // Anything else — regex fragments and similar punctuation-laden strings scraped from
+        // minified JS by IL/source scanners — would be emitted as an unparseable declaration
+        // that can take the rest of the stylesheet down with it.
+        if (!IsValidPropertyName(propertyName))
+        {
+            return false;
+        }
+
         // Parse the value for any special handling
         var parsed = _arbitraryValueParser.Parse(value, ArbitraryValueType.Brackets);
         if (!parsed.IsValid)
@@ -190,6 +199,41 @@ internal sealed class UtilityMatcher
         }
 
         value = parsed.Value!;
+        return true;
+    }
+
+    /// <summary>
+    /// Tests whether a string is a plausible CSS property name: an ident of ASCII letters,
+    /// digits, hyphens, and underscores, starting with a letter or underscore after at most
+    /// two leading hyphens (vendor prefix `-webkit-…` or custom property `--foo`).
+    /// </summary>
+    private static bool IsValidPropertyName(string name)
+    {
+        var start = 0;
+        while (start < name.Length && name[start] == '-')
+        {
+            start++;
+        }
+
+        if (start > 2 || start == name.Length)
+        {
+            return false;
+        }
+
+        if (!char.IsAsciiLetter(name[start]) && name[start] != '_')
+        {
+            return false;
+        }
+
+        for (var i = start + 1; i < name.Length; i++)
+        {
+            var c = name[i];
+            if (!char.IsAsciiLetterOrDigit(c) && c != '-' && c != '_')
+            {
+                return false;
+            }
+        }
+
         return true;
     }
 

--- a/tests/MonorailCss.Tests/CssFrameworkTests.cs
+++ b/tests/MonorailCss.Tests/CssFrameworkTests.cs
@@ -29,6 +29,24 @@ public partial class CssFrameworkTests
         detailed.GeneratedCss.ShouldBe("");
     }
 
+    [Theory]
+    // Regex literals scraped out of minified JS (e.g. Blazor's dotnet.runtime.js) by class
+    // scanners. Before property/bracket validation these compiled as arbitrary properties;
+    // the emitted declaration's unbalanced `[` made browsers drop every stylesheet rule
+    // after it (the alphabetically-late dark: variants, in practice).
+    [InlineData(@"[(?<funcNum>\d+)\]:0x[a-fA-F\d]")]
+    [InlineData(@"[0-9a-z\-#;/?:@&=+$,_.!~*'()\[\]]")]
+    [InlineData(@"[^:()]")]
+    public void Process_ScannerNoiseCandidates_EmitNoArbitraryProperty(string input)
+    {
+        var result = _framework.Process(input);
+
+        result.ShouldNotContain("funcNum");
+        result.ShouldNotContain("0x[");
+        result.ShouldNotContain("a-fA-F");
+        result.ShouldNotContain("0-9a-z");
+    }
+
     [Fact]
     public void Process_ShouldHandleNullInput()
     {

--- a/tests/MonorailCss.Tests/Parser/CandidateParserTests.cs
+++ b/tests/MonorailCss.Tests/Parser/CandidateParserTests.cs
@@ -101,6 +101,8 @@ public class CandidateParserTests
     [InlineData("[display:block]", "display", "block")]
     [InlineData("[margin:10px]", "margin", "10px")]
     [InlineData("[color:red]", "color", "red")]
+    [InlineData("[-webkit-line-clamp:2]", "-webkit-line-clamp", "2")]
+    [InlineData("[tab-size:4]", "tab-size", "4")]
     public void TryParseCandidate_WithArbitraryProperty_ParsesCorrectly(string input, string expectedProperty, string expectedValue)
     {
         // Arrange & Act
@@ -868,6 +870,17 @@ public class CandidateParserTests
     [InlineData("bg-[red;color:blue]")]           // Semicolon in value
     [InlineData("[color:red}html{color:blue]")]   // Braces in value
 
+    // Property is not a CSS identifier (scanner noise from minified JS regex literals)
+    [InlineData("[^:()]")]                        // Regex char-class fragment as property
+    [InlineData("[color(:red]")]                  // Punctuation in property name
+
+    // Unbalanced brackets/parens in arbitrary values — emitting these would make the
+    // browser swallow every stylesheet rule after the stray opener
+    [InlineData("[color:rgb(255,0,0]")]           // Unclosed function paren
+    [InlineData("[color:red)]")]                  // Stray closing paren
+    [InlineData("text-[rgb(255,0,0]")]            // Unclosed function paren in functional value
+    [InlineData("h-[100px]]")]                    // Extra closing bracket
+
     // Multiple modifiers (invalid)
     // (Static utilities with named modifiers like `flex/50` now parse successfully —
     // BaseStaticUtility.TryCompile drops them at compile time, while @container*
@@ -950,9 +963,7 @@ public class CandidateParserTests
     // These patterns are parsed successfully but would produce invalid CSS
     // The parser is intentionally lenient, leaving validation to later stages
     [InlineData("bg-[#0088cc", "bg", "[#0088cc")]      // Unclosed bracket - treated as named value
-    [InlineData("text-[rgb(255,0,0]", "text", "rgb(255,0,)0")] // Malformed function - parser tries to fix
     [InlineData("w-]100px[", "w", "]100px[")]          // Reversed brackets in value
-    [InlineData("h-[100px]]", "h", "100px]")]          // Extra closing bracket - one is consumed
     [InlineData("m-[[10px", "m", "[[10px")]            // Extra opening bracket
     [InlineData("text-[<script>alert('xss')</script>]", "text", "<script>alert('xss')</script>")] // HTML tags
     public void TryParseCandidate_MalformedButParseable_ParsesWithStrangeValues(


### PR DESCRIPTION
Class scanners (IL/source/static-web-asset) feed regex literals from
minified JS into the framework as candidates. Fragments like
`[(?<funcNum>\d+)\]:0x[a-fA-F\d]` (from Blazor's dotnet.runtime.js)
parsed as arbitrary properties and were emitted as CSS rules whose
unbalanced `[` makes browsers drop every rule that follows — in
practice the alphabetically-late dark: variant block, silently killing
dark mode on consuming sites.

Three layers of defense:
- UtilityMatcher: an arbitrary property's name must be a CSS ident
  (optional vendor/custom-property dashes + [A-Za-z_][A-Za-z0-9_-]*).
- ArbitraryValueParser: bracket values with unbalanced ()/[] outside
  string literals are invalid; this also retires the old behavior of
  'fixing' malformed functions (rgb(255,0,0] -> rgb(255,0,)0).
- Discovery: skip _framework/ static web assets entirely — .NET
  runtime and Blazor boot bundles never contain author-written
  utility classes.
