### PR TITLE
fix: variant composition in group/peer, arbitrary underscores, and @apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,24 @@ contract may still shift.
   regenerates CSS live. Previously these files were scanned once at startup but live edits to them
   were missed until the next process start.
 
+### Fixed
+
+- **`group-`/`peer-` now compose with any named-state sub-variant.** `GroupVariant`/`PeerVariant`
+  previously resolved their sub-variant against a hardcoded pseudo-class list (hover/focus/…), so
+  `group-aria-expanded`, `group-open`, `group-disabled`, `group-data-[state=open]` (and the `peer-`
+  equivalents) were silently dropped. They now delegate the sub-variant to the full variant
+  vocabulary (`VariantRegistry.TryApplySubVariant`), e.g. `group-aria-expanded:` →
+  `:is(:where(.group)[aria-expanded="true"] *)`. `group-hover`/`peer-focus` output is unchanged.
+- **Arbitrary variant underscores decode to spaces.** `[&_svg]:` now targets the descendant
+  `& svg` (emitted via CSS nesting, like `[&>x]`) instead of a literal `&_svg`; `\_` escapes a
+  literal underscore. `[@media_screen]`-style at-rule variants benefit too.
+- **`Applies` (`@apply`-style component classes) now honor variant selectors.** A variant in an
+  `Applies` value previously flattened onto the bare key selector, dropping the variant's selector
+  transform. Fixed for compound-class (`[&.is-active]:` → `.x.is-active`), sibling/descendant
+  combinator (`[&+&]:`, `[&_svg]:` → CSS-nested rules), and repeated functional variants:
+  `data-[type=a]:… data-[type=b]:…` no longer collapse into one rule (they were keyed by variant
+  *name*, now by canonical raw form) but emit distinct rules, each with its own selector and value.
+
 ## [0.1.0]
 
 First release out of alpha. MonorailCSS now ships as three packages —

--- a/src/MonorailCss/Processing/ApplyProcessor.cs
+++ b/src/MonorailCss/Processing/ApplyProcessor.cs
@@ -81,9 +81,11 @@ internal class ApplyProcessor
         // Handle special cases for component selectors
         if (selectorString.StartsWith("."))
         {
-            // Regular class selector - replace with component selector
+            // Regular class selector - replace with component selector. The delimiters mark where
+            // the base class ends and a variant's added qualifier begins: `.` (compound class, e.g.
+            // [&.is-active] → .x.is-active), `:` (pseudo), `[` (attribute), ` `/`>` (combinators).
             var className = selectorString[1..];
-            var parts = className.Split([':', '[', ' ', '>'], 2);
+            var parts = className.Split([':', '[', ' ', '>', '.'], 2);
             if (parts.Length > 1)
             {
                 // Has modifiers after the class name
@@ -214,10 +216,13 @@ internal class ApplyProcessor
         // Run the processed classes through the pipeline to apply all transformations
         _pipeline.Process(ImmutableList<AstNode>.Empty, pipelineContext);
 
-        // Now group the processed classes by variant
+        // Now group the processed classes by variant. Key on the canonical Raw form, not Name:
+        // two variants can share a Name but target different selectors (e.g. data-[type=a] and
+        // data-[type=b] are both Name "data"), and keying on Name would collapse them into one
+        // rule with the first selector and the last value.
         foreach (var processedClass in processedClasses)
         {
-            var variantKey = string.Join(":", processedClass.Candidate.Variants.Select(v => v.Name));
+            var variantKey = string.Join(":", processedClass.Candidate.Variants.Select(v => v.Raw));
 
             if (!variantGroups.TryGetValue(variantKey, out var value))
             {
@@ -303,7 +308,17 @@ internal class ApplyProcessor
 
                     // Extract the final selector and handle any at-rule wrappers
                     var finalSelector = ConvertAppliedSelectorToComponentSelector(appliedSelector, selectorBase) + pseudoElement;
-                    var styleRule = new StyleRule(finalSelector, mergedDeclarations.Cast<AstNode>().ToImmutableList());
+
+                    // A combinator arbitrary variant ([&+&], [&_svg], [&>*]) rides a NestedSelector
+                    // rather than a flat selector; emit it as a CSS-nested rule the same way the
+                    // utility pipeline does, otherwise the combinator is lost and the declarations
+                    // land flat on the component selector.
+                    AstNode styleRule = appliedSelector.Selector.NestedSelector != null
+                        ? new StyleRule(
+                            finalSelector,
+                            ImmutableList.Create<AstNode>(
+                                new NestedRule(appliedSelector.Selector.NestedSelector, mergedDeclarations.Cast<AstNode>().ToImmutableList())))
+                        : new StyleRule(finalSelector, mergedDeclarations.Cast<AstNode>().ToImmutableList());
 
                     // Wrap in any at-rules (media queries, supports, etc.)
                     AstNode ruleToAdd = styleRule;

--- a/src/MonorailCss/Variants/BuiltIn/ArbitraryVariant.cs
+++ b/src/MonorailCss/Variants/BuiltIn/ArbitraryVariant.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using MonorailCss.Css;
 
 namespace MonorailCss.Variants.BuiltIn;
@@ -40,6 +41,41 @@ internal class ArbitraryVariant : IVariant
         return nextChar == '>' || nextChar == '+' || nextChar == '~' || nextChar == ' ';
     }
 
+    /// <summary>
+    /// Decodes the arbitrary-value underscore convention: an unescaped <c>_</c> becomes a space
+    /// (so <c>[&amp;_svg]</c> targets the descendant <c>&amp; svg</c> and <c>[@media_screen]</c>
+    /// reads as <c>@media screen</c>), while <c>\_</c> is preserved as a literal underscore.
+    /// No-ops when there is no underscore.
+    /// </summary>
+    private static string DecodeUnderscores(string content)
+    {
+        if (!content.Contains('_'))
+        {
+            return content;
+        }
+
+        var sb = new StringBuilder(content.Length);
+        for (var i = 0; i < content.Length; i++)
+        {
+            var c = content[i];
+            if (c == '\\' && i + 1 < content.Length && content[i + 1] == '_')
+            {
+                sb.Append('_');
+                i++;
+            }
+            else if (c == '_')
+            {
+                sb.Append(' ');
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+
+        return sb.ToString();
+    }
+
     public bool TryApply(AppliedSelector current, VariantToken token, out AppliedSelector result)
     {
         result = current;
@@ -56,6 +92,10 @@ internal class ArbitraryVariant : IVariant
         {
             content = content[1..^1];
         }
+
+        // Underscores decode to spaces (the standard arbitrary-value rule) before we decide
+        // between nesting and a flat selector, so `[&_svg]` reads as the descendant `& svg`.
+        content = DecodeUnderscores(content);
 
         // Check if it's an at-rule
         if (content.StartsWith('@'))
@@ -79,7 +119,7 @@ internal class ArbitraryVariant : IVariant
             // Combinators: > (child), + (adjacent sibling), ~ (general sibling), space (descendant)
             if (NeedsCssNesting(content))
             {
-                // CSS nesting for combinators (e.g., [&>:first-child], [&+.sibling])
+                // CSS nesting for combinators (e.g., [&>:first-child], [&+.sibling], [&_svg])
                 result = current.TransformSelector(s => s.AsNestedSelector(content));
             }
             else

--- a/src/MonorailCss/Variants/BuiltIn/GroupVariant.cs
+++ b/src/MonorailCss/Variants/BuiltIn/GroupVariant.cs
@@ -3,13 +3,16 @@ using MonorailCss.Css;
 namespace MonorailCss.Variants.BuiltIn;
 
 /// <summary>
-/// Variant for group interactions (group-hover, group-focus, etc.).
+/// Variant for group interactions (group-hover, group-focus, group-aria-expanded, etc.).
 /// </summary>
 internal class GroupVariant : IVariant
 {
-    public GroupVariant(int weight)
+    private readonly VariantRegistry _registry;
+
+    public GroupVariant(int weight, VariantRegistry registry)
     {
         Weight = weight;
+        _registry = registry;
     }
 
     public string Name => "group";
@@ -58,12 +61,13 @@ internal class GroupVariant : IVariant
             return true;
         }
 
-        // Named pseudo-class compounds (group-hover, group-focus, etc.)
-        var pseudoClass = GetPseudoClass(token.Value);
-        if (pseudoClass != null)
+        // Named sub-variant (group-hover, group-focus, group-aria-expanded, group-open,
+        // group-data-[state=open], ...). Delegate to the full variant vocabulary by applying the
+        // sub-variant to the group reference, then descend from it: `:is(:where(.group)<sub> *)`.
+        if (_registry.TryApplySubVariant(token.Value, new Selector($":where({groupClass})"), out var composed))
         {
             result = current.TransformSelector(s =>
-                new Selector($"{s.Value}:is(:where({groupClass}){pseudoClass} *)"));
+                new Selector($"{s.Value}:is({composed.Value} *)"));
             return true;
         }
 
@@ -81,31 +85,19 @@ internal class GroupVariant : IVariant
         inner = string.Empty;
         return false;
     }
-
-    private string? GetPseudoClass(string value)
-    {
-        return value switch
-        {
-            "hover" => ":hover",
-            "focus" => ":focus",
-            "focus-visible" => ":focus-visible",
-            "active" => ":active",
-            "visited" => ":visited",
-            "disabled" => ":disabled",
-            "checked" => ":checked",
-            _ => null,
-        };
-    }
 }
 
 /// <summary>
-/// Variant for peer interactions (peer-hover, peer-focus, etc.).
+/// Variant for peer interactions (peer-hover, peer-focus, peer-aria-expanded, etc.).
 /// </summary>
 internal class PeerVariant : IVariant
 {
-    public PeerVariant(int weight)
+    private readonly VariantRegistry _registry;
+
+    public PeerVariant(int weight, VariantRegistry registry)
     {
         Weight = weight;
+        _registry = registry;
     }
 
     public string Name => "peer";
@@ -149,11 +141,11 @@ internal class PeerVariant : IVariant
             return true;
         }
 
-        var pseudoClass = GetPseudoClass(token.Value);
-        if (pseudoClass != null)
+        // Named sub-variant — delegate as with group, but as a following sibling: `~ *`.
+        if (_registry.TryApplySubVariant(token.Value, new Selector($":where({peerClass})"), out var composed))
         {
             result = current.TransformSelector(s =>
-                new Selector($"{s.Value}:is(:where({peerClass}){pseudoClass} ~ *)"));
+                new Selector($"{s.Value}:is({composed.Value} ~ *)"));
             return true;
         }
 
@@ -170,20 +162,5 @@ internal class PeerVariant : IVariant
 
         inner = string.Empty;
         return false;
-    }
-
-    private string? GetPseudoClass(string value)
-    {
-        return value switch
-        {
-            "hover" => ":hover",
-            "focus" => ":focus",
-            "focus-visible" => ":focus-visible",
-            "active" => ":active",
-            "visited" => ":visited",
-            "disabled" => ":disabled",
-            "checked" => ":checked",
-            _ => null,
-        };
     }
 }

--- a/src/MonorailCss/Variants/VariantRegistry.cs
+++ b/src/MonorailCss/Variants/VariantRegistry.cs
@@ -13,6 +13,7 @@ internal sealed class VariantRegistry
 {
     private readonly Dictionary<string, IVariant> _variants = new();
     private readonly List<IVariant> _orderedVariants = [];
+    private readonly VariantTokenizer _tokenizer = new();
 
     /// <summary>
     /// Registers a variant in the registry.
@@ -104,6 +105,47 @@ internal sealed class VariantRegistry
     }
 
     /// <summary>
+    /// Applies a single sub-variant — the part after <c>group-</c>/<c>peer-</c>, e.g. <c>hover</c>,
+    /// <c>aria-expanded</c>, <c>open</c>, or <c>data-[state=open]</c> — to <paramref name="baseSelector"/>
+    /// and returns the composed selector. This lets the group/peer compound variants reuse the full
+    /// variant vocabulary instead of a hardcoded pseudo-class list. Returns false when the sub-variant
+    /// isn't recognized or can't compose into a flat selector (it produces an at-rule wrapper or CSS
+    /// nesting, neither of which is meaningful qualifying a group/peer element).
+    /// </summary>
+    public bool TryApplySubVariant(string subVariant, Selector baseSelector, out Selector result)
+    {
+        result = baseSelector;
+
+        if (_tokenizer.ParseSegment(subVariant) is not { } token)
+        {
+            return false;
+        }
+
+        var applied = AppliedSelector.FromSelector(baseSelector);
+        foreach (var variant in _orderedVariants)
+        {
+            // A sub-variant is a single, non-compound step — never recurse back into group/peer.
+            if (variant is GroupVariant or PeerVariant)
+            {
+                continue;
+            }
+
+            if (variant.CanHandle(token) && variant.TryApply(applied, token, out var applyResult))
+            {
+                if (!applyResult.Wrappers.IsEmpty || applyResult.Selector.NestedSelector != null)
+                {
+                    return false;
+                }
+
+                result = applyResult.Selector;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Calculates the combined weight for a sequence of variants.
     /// Used for sorting classes with multiple variants.
     /// </summary>
@@ -156,8 +198,8 @@ internal sealed class VariantRegistry
         Register(new MotionVariant("motion-safe", 130));
         Register(new MotionVariant("motion-reduce", 140));
 
-        Register(new GroupVariant(200));
-        Register(new PeerVariant(250));
+        Register(new GroupVariant(200, this));
+        Register(new PeerVariant(250, this));
 
         // Tailwind v4 child-targeting variants:
         //   *:  → .class > *

--- a/src/MonorailCss/Variants/VariantTokenizer.cs
+++ b/src/MonorailCss/Variants/VariantTokenizer.cs
@@ -48,6 +48,13 @@ internal class VariantTokenizer
     }
 
     /// <summary>
+    /// Parses a single variant segment (no colon separators) into a token. Used to resolve the
+    /// sub-variant of a compound variant (e.g. the <c>aria-expanded</c> in <c>group-aria-expanded</c>)
+    /// against the full variant vocabulary. Returns null for an empty segment.
+    /// </summary>
+    public VariantToken? ParseSegment(string segment) => ParseVariantToken(segment);
+
+    /// <summary>
     /// Variant names that contain hyphens and resemble functional/compound forms (e.g.
     /// <c>not-open</c> looks like <c>not-[selector]</c>) but should resolve as a single
     /// static variant. Tokenization checks this set before the functional/compound rules so

--- a/tests/MonorailCss.Tests/AppliesIntegrationTest.cs
+++ b/tests/MonorailCss.Tests/AppliesIntegrationTest.cs
@@ -376,4 +376,86 @@ public class AppliesIntegrationTest
         result.ShouldContain(".p-shard-file");
         result.ShouldContain("background-color: color-mix(");
     }
+
+    // A variant in an Applies value must transform the component selector the same way it does on
+    // a utility class. These previously flattened onto the bare key (dropping the variant selector)
+    // or, for repeated functional variants, collapsed into one rule with the last value.
+
+    [Fact]
+    public void Process_WithSelfClassArbitraryVariant_ComposesCompoundSelector()
+    {
+        var settings = new CssFrameworkSettings
+        {
+            IncludePreflight = false,
+            Applies = ImmutableDictionary<string, string>.Empty
+                .Add(".x", "[&.on]:text-red-500"),
+        };
+
+        var result = new CssFramework(settings).Process("");
+
+        result.ShouldContain(".x.on {");
+        result.ShouldContain("color: var(--color-red-500)");
+    }
+
+    [Fact]
+    public void Process_WithSiblingArbitraryVariant_EmitsNestedCombinatorRule()
+    {
+        var settings = new CssFrameworkSettings
+        {
+            IncludePreflight = false,
+            Applies = ImmutableDictionary<string, string>.Empty
+                .Add(".x", "[&+&]:mt-4"),
+        };
+
+        var result = new CssFramework(settings).Process("");
+
+        // Emitted as CSS nesting: `.x { &+& { margin-top: … } }`.
+        result.ShouldContain("&+&");
+        result.ShouldContain("margin-top: calc(var(--spacing) * 4)");
+    }
+
+    [Fact]
+    public void Process_WithDescendantArbitraryVariant_EmitsNestedDescendantRule()
+    {
+        var settings = new CssFrameworkSettings
+        {
+            IncludePreflight = false,
+            Applies = ImmutableDictionary<string, string>.Empty
+                .Add(".x", "[&_svg]:w-4"),
+        };
+
+        var result = new CssFramework(settings).Process("");
+
+        // The underscore decodes to a descendant space, emitted as `.x { & svg { width: … } }`.
+        result.ShouldContain("& svg");
+        result.ShouldContain("width: calc(var(--spacing) * 4)");
+    }
+
+    [Fact]
+    public void Process_WithMultipleDataVariants_EmitsDistinctRules()
+    {
+        var settings = new CssFrameworkSettings
+        {
+            IncludePreflight = false,
+            Applies = ImmutableDictionary<string, string>.Empty
+                .Add(".x", "data-[type=a]:text-red-500 data-[type=b]:text-blue-500"),
+        };
+
+        var result = new CssFramework(settings).Process("");
+
+        // Two independent rules, each with its own selector AND its own value — not one merged rule.
+        result.ShouldContain(".x[data-type=\"a\"] {");
+        result.ShouldContain(".x[data-type=\"b\"] {");
+
+        // Each rule keeps its own colour (order-independent; declarations are flat, no nested braces).
+        static string RuleBody(string css, string selector)
+        {
+            var open = css.IndexOf('{', css.IndexOf(selector + " {", StringComparison.Ordinal));
+            var close = css.IndexOf('}', open);
+            return css.Substring(open, close - open);
+        }
+
+        RuleBody(result, ".x[data-type=\"a\"]").ShouldContain("--color-red-500");
+        RuleBody(result, ".x[data-type=\"b\"]").ShouldContain("--color-blue-500");
+    }
 }

--- a/tests/MonorailCss.Tests/Variants/VariantIntegrationTests.cs
+++ b/tests/MonorailCss.Tests/Variants/VariantIntegrationTests.cs
@@ -267,6 +267,51 @@ public class VariantIntegrationTests
         result.Selector.Value.ShouldBe(".border-red-500:is(:where(.peer):focus ~ *)");
     }
 
+    // group-/peer- are compound variants: their sub-variant should resolve against the full
+    // variant vocabulary, not a hardcoded pseudo-class list. Named-state sub-variants (aria-*,
+    // data-*, open, disabled, …) previously fell through and dropped the whole variant.
+    [Theory]
+    [InlineData("group-aria-expanded:rotate-180", "rotate-180", ".rotate-180:is(:where(.group)[aria-expanded=\"true\"] *)")]
+    [InlineData("group-open:flex", "flex", ".flex:is(:where(.group):is([open],:popover-open,:open) *)")]
+    [InlineData("group-data-[state=open]:block", "block", ".block:is(:where(.group)[data-state=\"open\"] *)")]
+    [InlineData("group-disabled:opacity-50", "opacity-50", ".opacity-50:is(:where(.group):disabled *)")]
+    public void ApplyGroupVariant_WithNamedStateSubVariant_ComposesSelector(string input, string baseClass, string expected)
+    {
+        _parser.TryParseCandidate(input, out var candidate);
+        var result = _registry.ApplyVariants(baseClass, candidate!.Variants);
+
+        result.Selector.Value.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ApplyPeerVariant_WithNamedStateSubVariant_ComposesSelector()
+    {
+        _parser.TryParseCandidate("peer-aria-checked:block", out var candidate);
+        var result = _registry.ApplyVariants("block", candidate!.Variants);
+
+        result.Selector.Value.ShouldBe(".block:is(:where(.peer)[aria-checked=\"true\"] ~ *)");
+    }
+
+    // An arbitrary variant's unescaped underscore decodes to a descendant space, so [&_svg]
+    // targets `& svg` (emitted via CSS nesting) rather than a literal `&_svg`.
+    [Fact]
+    public void ApplyArbitraryVariant_WithDescendantUnderscore_ProducesNestedDescendant()
+    {
+        _parser.TryParseCandidate("[&_svg]:w-4", out var candidate);
+        var result = _registry.ApplyVariants("w-4", candidate!.Variants);
+
+        result.Selector.NestedSelector.ShouldBe("& svg");
+    }
+
+    [Fact]
+    public void ApplyArbitraryVariant_WithEscapedUnderscore_KeepsLiteralUnderscore()
+    {
+        _parser.TryParseCandidate("[&.foo\\_bar]:w-4", out var candidate);
+        var result = _registry.ApplyVariants("w-4", candidate!.Variants);
+
+        result.Selector.Value.ShouldBe(".w-4.foo_bar");
+    }
+
     [Fact]
     public void ApplyPseudoElementVariants_ShouldAddDoubleColon()
     {

--- a/tests/MonorailCss.Tests/Variants/VariantRegistryTests.cs
+++ b/tests/MonorailCss.Tests/Variants/VariantRegistryTests.cs
@@ -108,9 +108,10 @@ public class VariantRegistryTests
     [Fact]
     public void ApplyVariants_ShouldHandleCompoundVariants()
     {
+        // group/peer are compound variants: they resolve their sub-variant (hover, focus, aria-*,
+        // …) against the rest of the vocabulary, so the full built-in set must be registered.
         var registry = new VariantRegistry();
-        registry.Register(new GroupVariant(200));
-        registry.Register(new PeerVariant(250));
+        registry.RegisterBuiltInVariants(new MonorailCss.Theme.Theme());
 
         var variants = new[]
         {


### PR DESCRIPTION
## Summary

Three related bug fixes in variant composition and `@apply`/`Applies` handling. Each was a case where a variant's selector transform was silently dropped.

### 1. `group-`/`peer-` compose with any named-state sub-variant

`GroupVariant`/`PeerVariant` resolved their sub-variant against a hardcoded pseudo-class list (`hover`/`focus`/…), so anything outside it — `group-aria-expanded`, `group-open`, `group-disabled`, `group-data-[state=open]`, and the `peer-` equivalents — was silently dropped. They now delegate the sub-variant to the full variant vocabulary via a new `VariantRegistry.TryApplySubVariant`, e.g.:

```
group-aria-expanded:  →  :is(:where(.group)[aria-expanded="true"] *)
```

`group-hover` / `peer-focus` output is unchanged.

### 2. Arbitrary variant underscores decode to spaces

`[&_svg]:` now targets the descendant `& svg` (emitted via CSS nesting, like `[&>x]`) instead of a literal `&_svg`. `\_` escapes a literal underscore. `[@media_screen]`-style at-rule variants benefit too.

### 3. `Applies` (`@apply`-style component classes) honor variant selectors

A variant in an `Applies` value previously flattened onto the bare key selector, dropping the variant's selector transform. Fixed for:

- compound-class (`[&.is-active]:` → `.x.is-active`)
- sibling/descendant combinators (`[&+&]:`, `[&_svg]:` → CSS-nested rules)
- repeated functional variants: `data-[type=a]:… data-[type=b]:…` no longer collapse into one rule (they were keyed by variant *name*; now keyed by canonical raw form) and emit distinct rules, each with its own selector and value.

## Testing

- `dotnet test tests/MonorailCss.Tests` — **7237 passed, 0 failed**
- New coverage: named-state group/peer sub-variants, arbitrary-underscore decode (descendant + escaped literal), and the four `Applies` scenarios above.
