### PR TITLE
feat(docs): add interactive playground

### DIFF
--- a/MonorailCss.sln
+++ b/MonorailCss.sln
@@ -33,6 +33,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonorailCss.Build.Tasks.Tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonorailCss.SourceGenerator", "src\MonorailCss.SourceGenerator\MonorailCss.SourceGenerator.csproj", "{9ABB6D5F-126F-48DB-B73A-D512C76A6B44}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonorailCss.Docs.Client", "docs\MonorailCss.Docs.Client\MonorailCss.Docs.Client.csproj", "{AA502B61-FE0D-4C66-84BE-E3451F925CB8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -187,6 +189,18 @@ Global
 		{9ABB6D5F-126F-48DB-B73A-D512C76A6B44}.Release|x64.Build.0 = Release|Any CPU
 		{9ABB6D5F-126F-48DB-B73A-D512C76A6B44}.Release|x86.ActiveCfg = Release|Any CPU
 		{9ABB6D5F-126F-48DB-B73A-D512C76A6B44}.Release|x86.Build.0 = Release|Any CPU
+		{AA502B61-FE0D-4C66-84BE-E3451F925CB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA502B61-FE0D-4C66-84BE-E3451F925CB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA502B61-FE0D-4C66-84BE-E3451F925CB8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AA502B61-FE0D-4C66-84BE-E3451F925CB8}.Debug|x64.Build.0 = Debug|Any CPU
+		{AA502B61-FE0D-4C66-84BE-E3451F925CB8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AA502B61-FE0D-4C66-84BE-E3451F925CB8}.Debug|x86.Build.0 = Debug|Any CPU
+		{AA502B61-FE0D-4C66-84BE-E3451F925CB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA502B61-FE0D-4C66-84BE-E3451F925CB8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA502B61-FE0D-4C66-84BE-E3451F925CB8}.Release|x64.ActiveCfg = Release|Any CPU
+		{AA502B61-FE0D-4C66-84BE-E3451F925CB8}.Release|x64.Build.0 = Release|Any CPU
+		{AA502B61-FE0D-4C66-84BE-E3451F925CB8}.Release|x86.ActiveCfg = Release|Any CPU
+		{AA502B61-FE0D-4C66-84BE-E3451F925CB8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -204,5 +218,6 @@ Global
 		{07BF4948-3A48-4631-8A72-EEEF9D2C5986} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{08ACD7FE-5E55-493A-9EF2-8FC6262F0536} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{9ABB6D5F-126F-48DB-B73A-D512C76A6B44} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{AA502B61-FE0D-4C66-84BE-E3451F925CB8} = {208BA388-4CEE-2CBF-559C-5607C099C1F8}
 	EndGlobalSection
 EndGlobal

--- a/docs/MonorailCss.Docs.Client/CssParser.cs
+++ b/docs/MonorailCss.Docs.Client/CssParser.cs
@@ -1,0 +1,37 @@
+using System.Text.RegularExpressions;
+
+namespace MonorailCss.Docs.Client;
+
+/// <summary>
+/// Extracts utility class names from the HTML the user types, and detects whether the
+/// caret sits inside a <c>class="…"</c> attribute (for the per-class CSS hover). Ported
+/// from tests/TryMonorail.
+/// </summary>
+internal static partial class CssParser
+{
+    [GeneratedRegex("""
+                    class\s*=\s*(['"])(?<value>.*?)\1
+                    """, RegexOptions.CultureInvariant, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex FindCssClassRegex();
+
+    [GeneratedRegex("<.*class\\s*=\\s*['|\"]([^\"]*)?$", RegexOptions.CultureInvariant,
+        matchTimeoutMilliseconds: 1000)]
+    private static partial Regex IsInCssClassReg();
+
+    public static bool IsInCssClass(string html)
+    {
+        return IsInCssClassReg().IsMatch(html);
+    }
+
+    public static IEnumerable<string> GetCssClasses(string html)
+    {
+        var matches = FindCssClassRegex().Matches(html);
+        var results = new string[matches.Count];
+        for (var i = 0; i < matches.Count; i++)
+        {
+            results[i] = matches[i].Groups["value"].Captures[0].Value;
+        }
+
+        return results;
+    }
+}

--- a/docs/MonorailCss.Docs.Client/DebounceHelper.cs
+++ b/docs/MonorailCss.Docs.Client/DebounceHelper.cs
@@ -1,0 +1,33 @@
+namespace MonorailCss.Docs.Client;
+
+/// <summary>
+/// Debounces the live re-compile: typing fires a change event per keystroke, but a full
+/// parse + CSS generation pass shouldn't run mid-word. Ported from tests/TryMonorail.
+/// </summary>
+internal sealed class DebounceHelper
+{
+    private CancellationTokenSource? _debounceToken;
+
+    public async Task<T?> DebounceAsync<T>(Func<CancellationToken, Task<T>> func, int milliseconds = 1000)
+    {
+        try
+        {
+            // Cancel the previous pending run.
+            _debounceToken?.Cancel();
+
+            // Assign a new token for this run.
+            _debounceToken = new CancellationTokenSource();
+
+            // Wait out the quiet window.
+            await Task.Delay(milliseconds, _debounceToken.Token);
+
+            // Throw if a newer keystroke cancelled us.
+            _debounceToken.Token.ThrowIfCancellationRequested();
+
+            return await func(_debounceToken.Token);
+        }
+        catch (TaskCanceledException) { }
+
+        return default;
+    }
+}

--- a/docs/MonorailCss.Docs.Client/DocsTheme.cs
+++ b/docs/MonorailCss.Docs.Client/DocsTheme.cs
@@ -1,0 +1,103 @@
+using System.Collections.Immutable;
+
+namespace MonorailCss.Docs.Client;
+
+/// <summary>
+/// Builds the CssFramework the playground uses to compile the user's classes in the browser.
+/// The palettes (sanibel/frosted/mixed/happily), the semantic primary/accent/base mapping,
+/// and the font families mirror the host's registration in
+/// <c>docs/MonorailCss.Docs/Program.cs</c> so previews render in the same colour scheme and
+/// type as the rest of the docs site.
+///
+/// The host uses Pennington's <c>NamedColorScheme.ApplyToTheme</c> for the semantic mapping,
+/// which is a server-side package we don't want in the WASM client — so we reproduce the same
+/// effect with core <see cref="Theme.Theme.MapColorPalette"/> calls
+/// (--color-primary-* -> var(--color-sanibel-*), etc.). Keep the two in sync if either changes.
+/// </summary>
+internal static class DocsTheme
+{
+    /// <summary>
+    /// A CssFramework themed to match the docs site. <paramref name="includePreflight"/> is on
+    /// for the preview iframe (a clean reset, Tailwind-Play style) and off for the "generated
+    /// CSS" pane and the per-class hover, which should show only the utilities the classes emit.
+    /// </summary>
+    public static CssFramework CreateFramework(bool includePreflight) => new(new CssFrameworkSettings
+    {
+        Theme = ApplyDocsTheme(Theme.Theme.CreateWithDefaults()),
+        IncludePreflight = includePreflight,
+    });
+
+    private static Theme.Theme ApplyDocsTheme(Theme.Theme baseTheme) => baseTheme
+        .AddColorPalette("sanibel", Sanibel)
+        .AddColorPalette("frosted", Frosted)
+        .AddColorPalette("mixed", Mixed)
+        .AddColorPalette("happily", Happily)
+        // Semantic aliases — the same mapping NamedColorScheme applies on the host.
+        .MapColorPalette("sanibel", "primary")
+        .MapColorPalette("mixed", "accent")
+        .MapColorPalette("frosted", "base")
+        .MapColorPalette("happily", "tertiary-one")
+        .AddFontFamily("display", "'Jost', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif")
+        .AddFontFamily("sans", "'Nunito', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif")
+        .AddFontFamily("mono", "'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace");
+
+    private static readonly ImmutableDictionary<string, string> Sanibel = new Dictionary<string, string>
+    {
+        { "50",  "oklch(97% 0.007 52.073)" },
+        { "100", "oklch(94% 0.017 52.073)" },
+        { "200", "oklch(89% 0.032 52.073)" },
+        { "300", "oklch(82% 0.058 52.073)" },
+        { "400", "oklch(72% 0.094 52.073)" },
+        { "500", "oklch(64% 0.123 52.073)" },
+        { "600", "oklch(56% 0.129 52.073)" },
+        { "700", "oklch(49% 0.118 52.073)" },
+        { "800", "oklch(43% 0.096 52.073)" },
+        { "900", "oklch(38% 0.076 52.073)" },
+        { "950", "oklch(27% 0.052 52.073)" },
+    }.ToImmutableDictionary();
+
+    private static readonly ImmutableDictionary<string, string> Frosted = new Dictionary<string, string>
+    {
+        { "50",  "oklch(98.5% 0.003 52.073)" },
+        { "100", "oklch(97% 0.004 52.073)" },
+        { "200", "oklch(92.5% 0.007 52.073)" },
+        { "300", "oklch(87% 0.014 52.073)" },
+        { "400", "oklch(71% 0.026 52.073)" },
+        { "500", "oklch(55% 0.040 52.073)" },
+        { "600", "oklch(44% 0.036 52.073)" },
+        { "700", "oklch(37% 0.034 52.073)" },
+        { "800", "oklch(27% 0.029 52.073)" },
+        { "900", "oklch(21% 0.025 52.073)" },
+        { "950", "oklch(14% 0.020 52.073)" },
+    }.ToImmutableDictionary();
+
+    private static readonly ImmutableDictionary<string, string> Mixed = new Dictionary<string, string>
+    {
+        { "50",  "oklch(97% 0.007 22.073)" },
+        { "100", "oklch(94% 0.017 22.073)" },
+        { "200", "oklch(89% 0.032 22.073)" },
+        { "300", "oklch(82% 0.058 22.073)" },
+        { "400", "oklch(72% 0.094 22.073)" },
+        { "500", "oklch(64% 0.123 22.073)" },
+        { "600", "oklch(56% 0.129 22.073)" },
+        { "700", "oklch(49% 0.118 22.073)" },
+        { "800", "oklch(43% 0.096 22.073)" },
+        { "900", "oklch(38% 0.076 22.073)" },
+        { "950", "oklch(27% 0.052 22.073)" },
+    }.ToImmutableDictionary();
+
+    private static readonly ImmutableDictionary<string, string> Happily = new Dictionary<string, string>
+    {
+        { "50",  "oklch(97% 0.007 82.073)" },
+        { "100", "oklch(94% 0.017 82.073)" },
+        { "200", "oklch(89% 0.032 82.073)" },
+        { "300", "oklch(82% 0.058 82.073)" },
+        { "400", "oklch(72% 0.094 82.073)" },
+        { "500", "oklch(64% 0.123 82.073)" },
+        { "600", "oklch(56% 0.129 82.073)" },
+        { "700", "oklch(49% 0.118 82.073)" },
+        { "800", "oklch(43% 0.096 82.073)" },
+        { "900", "oklch(38% 0.076 82.073)" },
+        { "950", "oklch(27% 0.052 82.073)" },
+    }.ToImmutableDictionary();
+}

--- a/docs/MonorailCss.Docs.Client/MonorailCss.Docs.Client.csproj
+++ b/docs/MonorailCss.Docs.Client/MonorailCss.Docs.Client.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>MonorailCss.Docs.Client</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+    <!-- Monaco editor for the playground island (HTML editing + per-class CSS hover). -->
+    <PackageReference Include="BlazorMonaco" Version="3.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The JIT CSS engine runs in the browser (WASM): the playground compiles the
+         user's utility classes to CSS entirely client-side. MonorailCss is IsAotCompatible,
+         so no reflection/native assets are pulled in. -->
+    <ProjectReference Include="..\..\src\MonorailCss\MonorailCss.csproj" />
+  </ItemGroup>
+</Project>

--- a/docs/MonorailCss.Docs.Client/PlaygroundIsland.razor
+++ b/docs/MonorailCss.Docs.Client/PlaygroundIsland.razor
@@ -1,0 +1,455 @@
+@* The interactive playground island: rendered in the browser (WebAssembly) inside the
+   static-SSR /playground page (Components/Pages/Playground.razor in the host). Kept
+   non-routable so the host owns the /playground route and emits it statically; this
+   component just supplies the in-browser interactivity — it compiles the utility classes
+   you type to CSS with the real MonorailCss engine, live, entirely client-side.
+
+   Ported from tests/TryMonorail, restyled to the docs colour scheme (base/primary map to
+   the frosted/sanibel palettes via /styles.css) and laid out full-height like the Beck
+   playground. *@
+@rendermode InteractiveWebAssembly
+@inject IJSRuntime Js
+@implements IAsyncDisposable
+@using System.Text
+@using Global = BlazorMonaco.Editor.Global
+
+<div class="flex h-full flex-col bg-base-50 dark:bg-base-950">
+    @* Panes: editor stack (HTML + generated CSS) on the left, live preview on the right.
+       Stacks vertically below lg. *@
+    <div class="grid min-h-0 flex-1 lg:grid-cols-2 max-lg:grid-rows-2">
+
+        @* Left column: HTML editor (top) over generated CSS (bottom). *@
+        <div class="grid min-h-0 grid-rows-2 border-base-200 dark:border-base-800 lg:border-r max-lg:border-b">
+
+            <div class="flex min-h-0 flex-col border-b border-base-200 dark:border-base-800">
+                <header class="flex flex-none items-center gap-2 border-b border-base-200 bg-base-100 px-4 py-[7px] font-mono text-[11.5px] text-base-500 dark:border-base-800 dark:bg-base-900 dark:text-base-400">
+                    <svg class="h-3.5 w-3.5 text-primary-600 dark:text-primary-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+                    <span>index.html</span>
+                    <button type="button" @onclick="ResetAsync"
+                            class="ml-auto rounded-md border border-base-200 px-2 py-1 text-[11px] font-medium text-base-600 transition-colors hover:border-base-300 hover:text-base-900 dark:border-base-800 dark:text-base-400 dark:hover:border-base-700 dark:hover:text-base-50">
+                        Reset
+                    </button>
+                </header>
+                <div class="min-h-0 flex-auto">
+                    <StandaloneCodeEditor @ref="_htmlEditor" Id="pg-html" CssClass="h-full w-full"
+                                          ConstructionOptions="HtmlEditorOptions"
+                                          OnDidInit="EditorInitAsync"
+                                          OnDidChangeModelContent="ModelChangedAsync" />
+                </div>
+            </div>
+
+            <div class="flex min-h-0 flex-col">
+                <header class="flex flex-none items-center gap-2 border-b border-base-200 bg-base-100 px-4 py-[7px] font-mono text-[11.5px] text-base-500 dark:border-base-800 dark:bg-base-900 dark:text-base-400">
+                    <svg class="h-3.5 w-3.5 text-primary-600 dark:text-primary-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 3h16a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z"/><path d="M8 8h8M8 12h8M8 16h5"/></svg>
+                    <span>generated.css</span>
+                </header>
+                <div class="min-h-0 flex-auto">
+                    <StandaloneCodeEditor @ref="_cssEditor" Id="pg-css" CssClass="h-full w-full"
+                                          ConstructionOptions="CssViewerOptions" />
+                </div>
+            </div>
+        </div>
+
+        @* Right column: sandboxed live preview. *@
+        <div class="flex min-h-0 flex-col">
+            <header class="flex flex-none items-center gap-2 border-b border-base-200 bg-base-100 px-4 py-[7px] font-mono text-[11.5px] text-base-500 dark:border-base-800 dark:bg-base-900 dark:text-base-400">
+                <span>preview</span>
+                <span class="ml-auto inline-flex items-center gap-1.5 text-primary-700 dark:text-primary-400">
+                    <span class="h-[7px] w-[7px] animate-pulse rounded-full bg-primary-600 dark:bg-primary-400"></span>live
+                </span>
+            </header>
+            <div class="flex min-h-0 flex-1">
+                <PreviewViewer @ref="_preview" />
+            </div>
+        </div>
+    </div>
+
+    @* Status bar. *@
+    <div class="flex flex-none items-center gap-4 border-t border-base-200 bg-base-100 px-5 py-[7px] font-mono text-[11.5px] text-base-500 dark:border-base-800 dark:bg-base-900 dark:text-base-400">
+        <span>@_classCount classes</span>
+        <span>@FormatBytes(_cssBytes) css</span>
+        <span class="ml-auto">Compiled live by MonorailCss</span>
+    </div>
+</div>
+
+@code {
+    private StandaloneCodeEditor _htmlEditor = null!;
+    private StandaloneCodeEditor _cssEditor = null!;
+    private PreviewViewer _preview = null!;
+
+    // Two engines, both on the docs palette: one with preflight for the isolated preview
+    // iframe (a clean reset), one without for the "generated CSS" pane and the per-class hover.
+    private readonly CssFramework _previewFramework = DocsTheme.CreateFramework(includePreflight: true);
+    private readonly CssFramework _displayFramework = DocsTheme.CreateFramework(includePreflight: false);
+
+    private readonly DebounceHelper _debouncer = new();
+    private DotNetObjectReference<PlaygroundIsland>? _selfRef;
+
+    private string _previousCss = string.Empty;
+    private int _classCount;
+    private int _cssBytes;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        await RegisterHoverProviderAsync();
+        _selfRef = DotNetObjectReference.Create(this);
+        var theme = await Js.InvokeAsync<string>("monorailPlayground.observeTheme", _selfRef);
+        await Global.SetTheme(Js, theme == "dark" ? "monorail-dark" : "monorail-light");
+    }
+
+    // Flip the editor themes when the docs light/dark toggle stamps/removes `.dark` on <html>.
+    [JSInvokable]
+    public async Task OnHostThemeChanged(string theme) =>
+        await Global.SetTheme(Js, theme == "dark" ? "monorail-dark" : "monorail-light");
+
+    private async Task EditorInitAsync()
+    {
+        await DefineThemesAsync();
+        var dark = await Js.InvokeAsync<bool>("monorailPlayground.isDark");
+        await Global.SetTheme(Js, dark ? "monorail-dark" : "monorail-light");
+
+        // Seed the welcome document. SetValue raises OnDidChangeModelContent, which the
+        // debounce collapses into the first compile; push once explicitly too so the preview
+        // paints immediately rather than after the debounce window.
+        await _htmlEditor.SetValue(InitialHtml);
+        await UpdateViewAsync();
+    }
+
+    private async Task<bool> ModelChangedAsync() =>
+        await _debouncer.DebounceAsync(async _ =>
+        {
+            await UpdateViewAsync();
+            return true;
+        }, 200);
+
+    private async Task ResetAsync()
+    {
+        await _htmlEditor.SetValue(InitialHtml);
+        await UpdateViewAsync();
+    }
+
+    private async Task UpdateViewAsync()
+    {
+        var html = await _htmlEditor.GetValue();
+        var classAttributes = CssParser.GetCssClasses(html).ToArray();
+        _classCount = classAttributes
+            .SelectMany(a => a.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .Distinct()
+            .Count();
+
+        // Preview gets the preflighted CSS; the pane shows the utilities only.
+        var previewCss = _previewFramework.Process(classAttributes);
+        var displayCss = _displayFramework.Process(classAttributes);
+        _cssBytes = Encoding.UTF8.GetByteCount(displayCss);
+
+        if (_previousCss != displayCss)
+        {
+            await _cssEditor.SetValue(displayCss);
+            _previousCss = displayCss;
+        }
+
+        await _preview.UpdateAsync(html, previewCss);
+        StateHasChanged();
+    }
+
+    // ---- per-class CSS hover -------------------------------------------------
+    // Hovering a utility class inside a class="…" attribute shows the CSS it compiles to.
+    private async Task RegisterHoverProviderAsync()
+    {
+        await BlazorMonaco.Languages.Global.RegisterHoverProviderAsync(Js, "html", async (uri, position, _) =>
+        {
+            var model = await Global.GetModel(Js, uri);
+            if (model == null)
+            {
+                return null;
+            }
+
+            var utilityClass = await GetUtilityClassAtPositionAsync(model, position);
+            if (utilityClass == null)
+            {
+                return null;
+            }
+
+            var css = ExtractLayerContent(_displayFramework.Process(utilityClass.ClassName));
+            if (string.IsNullOrWhiteSpace(css))
+            {
+                return null;
+            }
+
+            return new Hover
+            {
+                Contents = [new MarkdownString { Value = $"```css\n{css}\n```", SupportThemeIcons = false }],
+                Range = new BlazorMonaco.Range
+                {
+                    StartLineNumber = position.LineNumber,
+                    EndLineNumber = position.LineNumber,
+                    StartColumn = utilityClass.StartColumn,
+                    EndColumn = utilityClass.EndColumn,
+                },
+            };
+        });
+    }
+
+    private sealed record UtilityClassLocation(string ClassName, int StartColumn, int EndColumn);
+
+    private static async Task<UtilityClassLocation?> GetUtilityClassAtPositionAsync(TextModel model, Position position)
+    {
+        var lineContent = await model.GetLineContent(position.LineNumber);
+        if (string.IsNullOrEmpty(lineContent))
+        {
+            return null;
+        }
+
+        // Monaco columns are 1-indexed; convert to 0-indexed for string work.
+        var cursorIndex = position.Column - 1;
+        if (cursorIndex < 0 || cursorIndex > lineContent.Length)
+        {
+            return null;
+        }
+
+        // Only offer a hover when the caret sits inside a class attribute.
+        var textUpToCursor = lineContent[..cursorIndex];
+        if (!CssParser.IsInCssClass(textUpToCursor))
+        {
+            return null;
+        }
+
+        static bool IsDelimiter(char c) => c is ' ' or '\t' or '"' or '\'' or '<' or '>' or '\n' or '\r';
+
+        if (cursorIndex < lineContent.Length && IsDelimiter(lineContent[cursorIndex]))
+        {
+            return null;
+        }
+
+        var startIndex = cursorIndex;
+        while (startIndex > 0 && !IsDelimiter(lineContent[startIndex - 1]))
+        {
+            startIndex--;
+        }
+
+        var endIndex = cursorIndex;
+        while (endIndex < lineContent.Length && !IsDelimiter(lineContent[endIndex]))
+        {
+            endIndex++;
+        }
+
+        var className = lineContent.Substring(startIndex, endIndex - startIndex);
+        if (string.IsNullOrWhiteSpace(className))
+        {
+            return null;
+        }
+
+        // Back to 1-indexed Monaco columns.
+        return new UtilityClassLocation(className, startIndex + 1, endIndex + 1);
+    }
+
+    // ---- Monaco setup --------------------------------------------------------
+    private static StandaloneEditorConstructionOptions StandardOptions() => new()
+    {
+        AutomaticLayout = true,
+        GlyphMargin = false,
+        Scrollbar = new EditorScrollbarOptions { HorizontalScrollbarSize = 8, VerticalScrollbarSize = 8 },
+        RenderLineHighlight = "none",
+        FontFamily = "'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace",
+        FontSize = 13,
+        LineHeight = 21,
+        ColorDecorators = true,
+        Padding = new EditorPaddingOptions { Top = 10, Bottom = 10 },
+        Hover = new EditorHoverOptions { Enabled = true, Delay = 200 },
+        Minimap = new EditorMinimapOptions { Enabled = false },
+        Contextmenu = false,
+        Theme = "monorail-light",
+    };
+
+    private static StandaloneEditorConstructionOptions HtmlEditorOptions(StandaloneCodeEditor _)
+    {
+        var opts = StandardOptions();
+        opts.Language = "html";
+        return opts;
+    }
+
+    private static StandaloneEditorConstructionOptions CssViewerOptions(StandaloneCodeEditor _)
+    {
+        var opts = StandardOptions();
+        opts.Language = "css";
+        opts.ReadOnly = true;
+        opts.ColorDecorators = false;
+        return opts;
+    }
+
+    // Two brand-tinted Monaco themes; background transparent so the pane's base-* colour shows
+    // through and the editor tracks the docs light/dark toggle.
+    private async Task DefineThemesAsync()
+    {
+        await Global.DefineTheme(Js, "monorail-light", new StandaloneThemeData
+        {
+            Base = "vs",
+            Inherit = true,
+            Rules = [],
+            Colors = new Dictionary<string, string>
+            {
+                ["editor.background"] = "#00000000",
+                ["editorLineNumber.foreground"] = "#b8b2ab",
+                ["editorLineNumber.activeForeground"] = "#6b645c",
+                ["editorCursor.foreground"] = "#8a5a2b",
+                ["editor.selectionBackground"] = "#e7d8c6",
+            },
+        });
+
+        await Global.DefineTheme(Js, "monorail-dark", new StandaloneThemeData
+        {
+            Base = "vs-dark",
+            Inherit = true,
+            Rules = [],
+            Colors = new Dictionary<string, string>
+            {
+                ["editor.background"] = "#00000000",
+                ["editorLineNumber.foreground"] = "#4a453f",
+                ["editorLineNumber.activeForeground"] = "#a39c93",
+                ["editorCursor.foreground"] = "#d6a06a",
+                ["editor.selectionBackground"] = "#3a3128",
+            },
+        });
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // _selfRef is only created in OnAfterRenderAsync, which runs in the browser — never
+        // during the server prerender. So its presence is our signal that JS is actually
+        // available; skipping the call otherwise avoids "interop during static rendering".
+        if (_selfRef is null)
+        {
+            return;
+        }
+
+        try
+        {
+            // Disconnect the theme MutationObserver before dropping the .NET ref it calls back into.
+            await Js.InvokeVoidAsync("monorailPlayground.disposeTheme");
+        }
+        catch (JSDisconnectedException)
+        {
+            // Circuit already gone (page unloading) — nothing to clean up.
+        }
+
+        _selfRef.Dispose();
+    }
+
+    // ---- helpers -------------------------------------------------------------
+    private static string FormatBytes(int bytes) =>
+        bytes < 1024 ? $"{bytes} B" : $"{bytes / 1024.0:0.0} KB";
+
+    // Show only the `@layer utilities` body in the hover / a lean view — strip the surrounding
+    // theme scaffolding. Ported from tests/TryMonorail.
+    private static string ExtractLayerContent(string css)
+    {
+        if (!css.Contains("@layer"))
+        {
+            return css;
+        }
+
+        var layerStart = css.IndexOf("@layer utilities", StringComparison.Ordinal);
+        if (layerStart == -1)
+        {
+            return css;
+        }
+
+        var openBraceIndex = css.IndexOf('{', layerStart);
+        if (openBraceIndex == -1)
+        {
+            return css;
+        }
+
+        var braceCount = 1;
+        var closeBraceIndex = openBraceIndex + 1;
+        while (closeBraceIndex < css.Length && braceCount > 0)
+        {
+            switch (css[closeBraceIndex])
+            {
+                case '{': braceCount++; break;
+                case '}': braceCount--; break;
+            }
+
+            closeBraceIndex++;
+        }
+
+        if (braceCount != 0)
+        {
+            return css;
+        }
+
+        var content = css.Substring(openBraceIndex + 1, closeBraceIndex - openBraceIndex - 2);
+        return RemoveCommonLeadingWhitespace(content);
+    }
+
+    private static string RemoveCommonLeadingWhitespace(string text)
+    {
+        var lines = text.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
+
+        var minLeadingSpaces = int.MaxValue;
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var leadingSpaces = 0;
+            foreach (var c in line)
+            {
+                if (c is ' ' or '\t')
+                {
+                    leadingSpaces++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            minLeadingSpaces = Math.Min(minLeadingSpaces, leadingSpaces);
+        }
+
+        if (minLeadingSpaces is int.MaxValue or 0)
+        {
+            return text.Trim('\r', '\n');
+        }
+
+        var result = new StringBuilder();
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                result.AppendLine();
+            }
+            else
+            {
+                result.AppendLine(line[Math.Min(minLeadingSpaces, line.Length)..]);
+            }
+        }
+
+        return result.ToString().Trim('\r', '\n');
+    }
+
+    private const string InitialHtml = """
+        <!-- Edit this markup — the preview and CSS recompile live in your browser. -->
+        <div class="grid min-h-screen place-items-center bg-gradient-to-br from-base-100 to-base-200 p-6 font-sans">
+          <div class="w-full max-w-sm rounded-3xl bg-base-50 p-8 shadow-2xl shadow-primary-950/10 ring-1 ring-base-950/5">
+            <div class="flex size-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary-500 to-accent-500 text-white shadow-lg shadow-primary-600/30">
+              <svg class="size-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m4 12 5 5L20 6" /></svg>
+            </div>
+            <h1 class="mt-6 text-2xl font-bold tracking-tight text-base-900">Styled by MonorailCss</h1>
+            <p class="mt-2 text-sm leading-relaxed text-base-600">Every class here compiled to CSS in your browser — edit the markup and watch it update live.</p>
+            <div class="mt-7 flex items-center gap-3">
+              <button class="flex-1 rounded-xl bg-primary-600 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-primary-700">Get started</button>
+              <button class="rounded-xl px-4 py-2.5 text-sm font-semibold text-base-600 transition-colors hover:bg-base-100">Docs</button>
+            </div>
+          </div>
+        </div>
+        """;
+}

--- a/docs/MonorailCss.Docs.Client/PreviewViewer.razor
+++ b/docs/MonorailCss.Docs.Client/PreviewViewer.razor
@@ -1,0 +1,122 @@
+@inject IJSRuntime Js
+
+@* Sandboxed iframe canvas. The compiled CSS (including preflight) and the user's HTML are
+   pushed in over postMessage, so the preview is fully isolated from the docs page's own
+   styles. Adapted from Tailwind Play via tests/TryMonorail. *@
+<iframe @ref="PreviewViewerIFrame" @onload="OnLoadAsync" class="h-full w-full flex-1 bg-white"
+        sandbox="allow-popups-to-escape-sandbox allow-scripts allow-popups allow-forms allow-pointer-lock allow-top-navigation allow-modals"
+        srcdoc="@PreviewHtml"></iframe>
+
+@code {
+    private ElementReference PreviewViewerIFrame { get; set; }
+
+    // The iframe's message listener only exists once its srcdoc has loaded. If UpdateAsync
+    // runs before that (the island can compile the first frame before the iframe is ready),
+    // stash the payload and flush it on load so the initial preview is never dropped.
+    private bool _loaded;
+    private PreviewData? _pending;
+
+    public async Task UpdateAsync(string html, string css)
+    {
+        _pending = new PreviewData { Html = html, Css = css };
+        if (_loaded)
+        {
+            await FlushAsync();
+        }
+    }
+
+    private async Task OnLoadAsync()
+    {
+        _loaded = true;
+        if (_pending is not null)
+        {
+            await FlushAsync();
+        }
+    }
+
+    private async Task FlushAsync() =>
+        await Js.InvokeVoidAsync("monorailPlayground.postPreviewMessage", PreviewViewerIFrame, _pending);
+
+    private sealed class PreviewData
+    {
+        public string Css { get; init; } = string.Empty;
+        public string Html { get; init; } = string.Empty;
+    }
+
+    private const string PreviewHtml = @"<!-- adapted from https://github.com/tailwindlabs/play.tailwindcss.com/blob/master/src/components/Preview.js -->
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset=""utf-8"">
+    <meta name=""viewport"" content=""width=device-width, initial-scale=1"">
+    <style id=""_style""></style>
+    <script>
+        var hasHtml = false
+        var hasCss = false
+        var visible = false
+        window.addEventListener('message', (e) => {
+            if (typeof e.data.clear !== 'undefined') {
+                setHtml()
+                setCss()
+                checkVisibility()
+                return
+            }
+            if (typeof e.data.css !== 'undefined') {
+                setCss(e.data.css)
+            }
+            if (typeof e.data.html !== 'undefined') {
+                setHtml(e.data.html)
+            }
+            checkVisibility()
+        })
+        function checkVisibility() {
+            if (!visible && hasHtml && hasCss) {
+                visible = true
+                document.body.style.display = ''
+            } else if (visible && (!hasHtml || !hasCss)) {
+                visible = false
+                document.body.style.display = 'none'
+            }
+        }
+        function setHtml(html) {
+            if (typeof html === 'undefined') {
+                document.body.innerHTML = ''
+                hasHtml = false
+            } else {
+                document.body.innerHTML = html
+                hasHtml = true
+            }
+        }
+        function setCss(css) {
+            const style = document.getElementById('_style')
+            const newStyle = document.createElement('style')
+            newStyle.id = '_style'
+            newStyle.innerHTML = typeof css === 'undefined' ? '' : css
+            style.parentNode.replaceChild(newStyle, style)
+            hasCss = typeof css === 'undefined' ? false : true
+        }
+    </script>
+</head>
+<body style=""display:none"">
+</body>
+<script>
+    // https://github.com/sveltejs/svelte-repl/blob/master/src/Output/srcdoc/index.html
+    // https://github.com/sveltejs/svelte-repl/blob/master/LICENSE
+    document.body.addEventListener('click', event => {
+        if (event.which !== 1) return;
+        if (event.metaKey || event.ctrlKey || event.shiftKey) return;
+        if (event.defaultPrevented) return;
+
+        // ensure target is a link
+        let el = event.target;
+        while (el && el.nodeName !== 'A') el = el.parentNode;
+        if (!el || el.nodeName !== 'A') return;
+
+        if (el.hasAttribute('download') || el.getAttribute('rel') === 'external' || el.target) return;
+
+        event.preventDefault();
+        window.open(el.href, '_blank');
+    });
+</script>
+</html>";
+}

--- a/docs/MonorailCss.Docs.Client/Program.cs
+++ b/docs/MonorailCss.Docs.Client/Program.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+// The WASM client hosts the docs' one interactive island — the /playground component,
+// which compiles utility classes to CSS entirely in the browser via the pure-C#
+// MonorailCss engine. The server project supplies every other (static SSR) page; here
+// we only build the host so the island's render mode can activate in the browser.
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+await builder.Build().RunAsync();

--- a/docs/MonorailCss.Docs.Client/_Imports.razor
+++ b/docs/MonorailCss.Docs.Client/_Imports.razor
@@ -1,0 +1,12 @@
+@using System.Net.Http
+@using System.Threading
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using MonorailCss
+@using MonorailCss.Docs.Client
+@using BlazorMonaco
+@using BlazorMonaco.Editor
+@using BlazorMonaco.Languages

--- a/docs/MonorailCss.Docs/Components/App.razor
+++ b/docs/MonorailCss.Docs/Components/App.razor
@@ -7,6 +7,11 @@
        charset meta past that limit. *@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    @* Anchors relative-URL resolution at the site root so the playground's Monaco AMD loader
+       resolves its module paths to /_content/... on the nested /playground route (without a
+       base it produces /playground_content/...). The rest of the site uses absolute /-prefixed
+       URLs, so this is otherwise a no-op. *@
+    <base href="/"/>
     <link rel="icon" href="/favicon.svg" type="image/svg+xml"/>
 
     @* Preload the two above-the-fold faces (Jost display for the logo/hero, Nunito
@@ -60,13 +65,37 @@
     <script src="/_content/Pennington.UI/scripts.js" defer></script>
     <script src="/_content/Pennington.UI/spa-engine.js" defer></script>
 
+    @* Monaco's stylesheet, declared statically so it survives navigation. editor.main.js
+       injects this link itself on a fresh load, but a client-side region swap into
+       /playground would boot Monaco with no CSS. Only the playground uses it; it is a tiny,
+       cached, no-op link on every other page. *@
+    <link rel="stylesheet" href="_content/BlazorMonaco/lib/monaco-editor/min/vs/editor/editor.main.css" />
+    @* Glue for the WebAssembly playground island (preview postMessage + editor theme sync). *@
+    <script src="/js/playground.js" defer></script>
+
     <HeadOutlet />
 </head>
-<body data-sidebar-open="false" class="bg-base-50 dark:bg-base-950 text-base-950 dark:text-base-50 font-sans data-[sidebar-open=true]:overflow-hidden overflow-y-scroll scrollbar-thin scrollbar-thumb-base-300 dark:scrollbar-thumb-base-700 scrollbar-track-base-50 dark:scrollbar-track-base-950 scrollbar-color">
+@* data-enhance-nav="false": the site already does client-side navigation with Pennington's
+   spa-engine, so Blazor's own enhanced navigation (from blazor.web.js, loaded below for the
+   WASM playground island) must stay out of the way. A full load into /playground is what the
+   Monaco editor needs anyway (see the Playground page's data-spa-reload link). *@
+<body data-sidebar-open="false" data-enhance-nav="false" class="bg-base-50 dark:bg-base-950 text-base-950 dark:text-base-50 font-sans data-[sidebar-open=true]:overflow-hidden overflow-y-scroll scrollbar-thin scrollbar-thumb-base-300 dark:scrollbar-thumb-base-700 scrollbar-track-base-50 dark:scrollbar-track-base-950 scrollbar-color">
 <Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
     </Found>
 </Router>
+
+@* Monaco (the playground editor): interop shim + AMD loader + editor bundle, served as static
+   web assets by the BlazorMonaco package referenced through MonorailCss.Docs.Client. Must
+   precede the Blazor script so the editor JS is present when the WASM island boots. *@
+<script src="_content/BlazorMonaco/jsInterop.js"></script>
+<script src="_content/BlazorMonaco/lib/monaco-editor/min/vs/loader.js"></script>
+<script src="_content/BlazorMonaco/lib/monaco-editor/min/vs/editor/editor.main.js"></script>
+
+@* Blazor runtime: activates the interactive-WebAssembly /playground island. Harmless on the
+   static pages — they carry no interactive components — and on the static export it just
+   boots the island in the browser with no server round-trip. *@
+<script src="_framework/blazor.web.js"></script>
 </body>
 </html>

--- a/docs/MonorailCss.Docs/Components/Layout/MainLayout.razor
+++ b/docs/MonorailCss.Docs/Components/Layout/MainLayout.razor
@@ -6,51 +6,7 @@
 <div class="min-h-screen font-sans text-base-950 dark:text-base-50 bg-base-50 dark:bg-base-950 [background-image:linear-gradient(rgba(232,148,95,0.025)_1px,transparent_1px),linear-gradient(90deg,rgba(232,148,95,0.025)_1px,transparent_1px)] [background-size:56px_56px] [background-attachment:fixed]">
 
     @* ─────────────────  Top nav  ───────────────── *@
-    <header class="sticky top-0 z-50 max-w-7xl mx-auto flex items-center gap-4 px-6 lg:px-8 py-3.5 border-b border-base-200 dark:border-base-800 bg-base-50/75 dark:bg-base-950/75 backdrop-blur-md supports-[backdrop-filter]:bg-base-50/60 dark:supports-[backdrop-filter]:bg-base-950/60">
-        <div class="flex items-center gap-3 flex-shrink-0">
-            <button id="sidebar-toggle"
-                    class="lg:hidden p-2 rounded-md text-base-900 dark:text-base-100 hover:bg-base-100 dark:hover:bg-base-900 transition-colors"
-                    aria-label="Toggle sidebar">
-                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-                </svg>
-            </button>
-
-            <a href="/" class="flex items-center">
-                <span class="font-display text-lg font-bold tracking-tight text-primary-700 dark:text-primary-400">
-                    Monorail<span class="font-normal text-base-950 dark:text-base-50">Css</span>
-                </span>
-            </a>
-        </div>
-
-        <div class="flex-1 flex justify-center min-w-0">
-            <button id="search-input" type="button" aria-label="Search docs"
-                    class="flex items-center gap-2 rounded-lg bg-base-100 dark:bg-base-900 border border-base-200 dark:border-base-800 text-base-600 dark:text-base-400 hover:bg-base-200/70 dark:hover:bg-base-800/70 transition-colors p-2 sm:py-[7px] sm:px-3 sm:text-[13px] sm:w-full sm:max-w-md">
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.35-4.35"/></svg>
-                <span class="hidden sm:inline">Search docs</span>
-                <span aria-hidden="true" class="hidden sm:inline-flex ml-auto font-mono text-[11px] border border-base-200 dark:border-base-800 px-1.5 py-px rounded">⌘K</span>
-            </button>
-        </div>
-
-        <div class="flex items-center gap-1 flex-shrink-0">
-            <a href="https://github.com/monorailcss/MonorailCss.Framework" target="_blank" rel="noopener noreferrer"
-               class="p-2 rounded-md text-base-900 dark:text-base-100 hover:text-accent-500 hover:bg-base-100 dark:hover:bg-base-900 transition-colors" aria-label="GitHub repository">
-                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                    <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
-                </svg>
-            </a>
-            <button type="button" onclick="window.toggleTheme()" aria-label="Toggle theme"
-                    class="p-2 rounded-md text-base-900 dark:text-base-100 hover:bg-base-100 dark:hover:bg-base-900 transition-colors">
-                <svg class="w-4 h-4 dark:hidden" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
-                </svg>
-                <svg class="w-4 h-4 hidden dark:block" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-                    <circle cx="12" cy="12" r="4"/>
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
-                </svg>
-            </button>
-        </div>
-    </header>
+    <SiteHeader />
 
     @* ─────────────────  3-column layout  ───────────────── *@
     <div class="max-w-7xl mx-auto grid lg:grid-cols-[280px_1fr]">

--- a/docs/MonorailCss.Docs/Components/Layout/PlaygroundLayout.razor
+++ b/docs/MonorailCss.Docs/Components/Layout/PlaygroundLayout.razor
@@ -1,0 +1,14 @@
+@inherits LayoutComponentBase
+
+@* Full-viewport playground shell: the same MonorailCss docs heading and colour scheme, but
+   the bar spans the full width and there is no sidebar or max-width cap — so the editor and
+   preview fill the screen, like the Beck playground. A fixed-height flex column: the header is
+   flex-none and the island fills the rest (min-h-0 lets it shrink to the viewport). *@
+<div class="h-screen flex flex-col overflow-hidden bg-base-50 dark:bg-base-950 text-base-950 dark:text-base-50 font-sans">
+    <SiteHeader ShowSidebarToggle="false"
+                HeaderClass="flex-none flex items-center gap-4 px-6 lg:px-8 py-3 border-b border-base-200 dark:border-base-800 bg-base-50/75 dark:bg-base-950/75 backdrop-blur-md supports-[backdrop-filter]:bg-base-50/60 dark:supports-[backdrop-filter]:bg-base-950/60" />
+
+    <main class="flex-1 min-h-0">
+        @Body
+    </main>
+</div>

--- a/docs/MonorailCss.Docs/Components/Layout/SiteHeader.razor
+++ b/docs/MonorailCss.Docs/Components/Layout/SiteHeader.razor
@@ -1,0 +1,67 @@
+@* The MonorailCss docs site header — logo, search, playground link, GitHub, theme toggle.
+   Shared by MainLayout (constrained, with the mobile sidebar toggle) and PlaygroundLayout
+   (full-width, no sidebar). The outer classes are passed in so each layout can position the
+   bar for its own context; the inner content stays identical so the heading reads the same. *@
+<header class="@HeaderClass">
+    <div class="flex items-center gap-3 flex-shrink-0">
+        @if (ShowSidebarToggle)
+        {
+            <button id="sidebar-toggle"
+                    class="lg:hidden p-2 rounded-md text-base-900 dark:text-base-100 hover:bg-base-100 dark:hover:bg-base-900 transition-colors"
+                    aria-label="Toggle sidebar">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+                </svg>
+            </button>
+        }
+
+        <a href="/" class="flex items-center">
+            <span class="font-display text-lg font-bold tracking-tight text-primary-700 dark:text-primary-400">
+                Monorail<span class="font-normal text-base-950 dark:text-base-50">Css</span>
+            </span>
+        </a>
+    </div>
+
+    <div class="flex-1 flex justify-center min-w-0">
+        <button id="search-input" type="button" aria-label="Search docs"
+                class="flex items-center gap-2 rounded-lg bg-base-100 dark:bg-base-900 border border-base-200 dark:border-base-800 text-base-600 dark:text-base-400 hover:bg-base-200/70 dark:hover:bg-base-800/70 transition-colors p-2 sm:py-[7px] sm:px-3 sm:text-[13px] sm:w-full sm:max-w-md">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.35-4.35"/></svg>
+            <span class="hidden sm:inline">Search docs</span>
+            <span aria-hidden="true" class="hidden sm:inline-flex ml-auto font-mono text-[11px] border border-base-200 dark:border-base-800 px-1.5 py-px rounded">⌘K</span>
+        </button>
+    </div>
+
+    <div class="flex items-center gap-1 flex-shrink-0">
+        @* Full page load into /playground so Monaco boots cleanly (see spa-engine's
+           data-spa-reload opt-out). *@
+        <a href="/playground" data-spa-reload
+           class="hidden sm:inline-flex px-3 py-1.5 rounded-md text-[13px] font-medium text-base-700 dark:text-base-300 hover:text-primary-700 dark:hover:text-primary-400 hover:bg-base-100 dark:hover:bg-base-900 transition-colors">
+            Playground
+        </a>
+        <a href="https://github.com/monorailcss/MonorailCss.Framework" target="_blank" rel="noopener noreferrer"
+           class="p-2 rounded-md text-base-900 dark:text-base-100 hover:text-accent-500 hover:bg-base-100 dark:hover:bg-base-900 transition-colors" aria-label="GitHub repository">
+            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
+            </svg>
+        </a>
+        <button type="button" onclick="window.toggleTheme()" aria-label="Toggle theme"
+                class="p-2 rounded-md text-base-900 dark:text-base-100 hover:bg-base-100 dark:hover:bg-base-900 transition-colors">
+            <svg class="w-4 h-4 dark:hidden" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+            </svg>
+            <svg class="w-4 h-4 hidden dark:block" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <circle cx="12" cy="12" r="4"/>
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
+            </svg>
+        </button>
+    </div>
+</header>
+
+@code {
+    /// <summary>Outer &lt;header&gt; utility classes; each layout positions the bar for its context.</summary>
+    [Parameter] public string HeaderClass { get; set; } =
+        "sticky top-0 z-50 max-w-7xl mx-auto flex items-center gap-4 px-6 lg:px-8 py-3.5 border-b border-base-200 dark:border-base-800 bg-base-50/75 dark:bg-base-950/75 backdrop-blur-md supports-[backdrop-filter]:bg-base-50/60 dark:supports-[backdrop-filter]:bg-base-950/60";
+
+    /// <summary>The mobile sidebar hamburger only makes sense where there is a sidebar (docs pages).</summary>
+    [Parameter] public bool ShowSidebarToggle { get; set; } = true;
+}

--- a/docs/MonorailCss.Docs/Components/Pages/Playground.razor
+++ b/docs/MonorailCss.Docs/Components/Pages/Playground.razor
@@ -1,0 +1,17 @@
+@page "/playground"
+@layout PlaygroundLayout
+@using MonorailCss.Docs.Client
+
+<PageTitle>Playground - MonorailCss</PageTitle>
+<HeadContent>
+    <meta name="description" content="Edit HTML with utility classes and watch the preview and generated CSS update live — compiled in your browser by the real MonorailCss engine." />
+    @* This page is a fixed-height shell; suppress the site-wide body scrollbar gutter so the
+       playground fills the viewport exactly. Reached via a full page load (data-spa-reload),
+       so this scoped override is present whenever the page is. *@
+    <style>body { overflow: hidden !important; }</style>
+</HeadContent>
+
+@* Static-SSR route so Pennington's crawler emits /playground into the static export; the
+   interactive UI is a WebAssembly island (MonorailCss.Docs.Client) that compiles utility
+   classes to CSS in the browser. Its own @@rendermode drives the interactivity. *@
+<PlaygroundIsland />

--- a/docs/MonorailCss.Docs/MonorailCss.Docs.csproj
+++ b/docs/MonorailCss.Docs/MonorailCss.Docs.csproj
@@ -15,6 +15,9 @@
     <PackageReference Include="Pennington.MonorailCss" Version="0.1.7" />
     <PackageReference Include="Pennington.TreeSitter" Version="0.1.7" />
     <PackageReference Include="Pennington.UI" Version="0.1.7" />
+    <!-- Host-side WebAssembly render-mode wiring (AddInteractiveWebAssembly*), which is not
+         part of the Microsoft.AspNetCore.App shared framework. Backs the /playground island. -->
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>
@@ -22,11 +25,17 @@
     <Watch Include="Components\**\*.razor" />
     <Watch Include="Components\**\*.razor.cs" />
     <Watch Include="..\MonorailCss.Docs.Samples\**\*.cs" />
+    <Watch Include="..\MonorailCss.Docs.Client\**\*.razor" />
+    <Watch Include="..\MonorailCss.Docs.Client\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\MonorailCss\MonorailCss.csproj" />
     <ProjectReference Include="..\MonorailCss.Docs.Samples\MonorailCss.Docs.Samples.csproj" />
+    <!-- The Blazor WebAssembly client: hosts the interactive /playground island. Referencing
+         it bundles its WASM payload into this host's static web assets, so the static export
+         ships it. -->
+    <ProjectReference Include="..\MonorailCss.Docs.Client\MonorailCss.Docs.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/docs/MonorailCss.Docs/Program.cs
+++ b/docs/MonorailCss.Docs/Program.cs
@@ -16,7 +16,12 @@ using Pennington.TreeSitter;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddRazorComponents();
+// Static SSR for the whole site PLUS interactive-WebAssembly components: the /playground
+// island (MonorailCss.Docs.Client) compiles utility classes to CSS entirely in the browser
+// via MonorailCss compiled to WASM. Every other page stays static SSR, so the site still
+// deploys as static files.
+builder.Services.AddRazorComponents()
+    .AddInteractiveWebAssemblyComponents();
 
 var colorScheme = new NamedColorScheme
 {
@@ -186,6 +191,10 @@ app.UsePennington();
 app.UseMonorailCss();
 app.UseAntiforgery();
 app.MapStaticAssets();
-app.MapRazorComponents<App>();
+app.MapRazorComponents<App>()
+    // The /playground route is a static-SSR page in this host; its interactive UI is a
+    // WebAssembly island (MonorailCss.Docs.Client) bundled via the project reference. No
+    // routable components live in the client assembly, so no AddAdditionalAssemblies is needed.
+    .AddInteractiveWebAssemblyRenderMode();
 
 await app.RunOrBuildAsync(args);

--- a/docs/MonorailCss.Docs/wwwroot/js/playground.js
+++ b/docs/MonorailCss.Docs/wwwroot/js/playground.js
@@ -1,0 +1,40 @@
+// Glue for the WebAssembly playground island (docs/MonorailCss.Docs.Client/PlaygroundIsland.razor).
+// Only the playground page uses this; it is inert everywhere else.
+(function () {
+    let themeObserver = null;
+
+    window.monorailPlayground = {
+        // Push {html, css} into the sandboxed preview iframe.
+        postPreviewMessage: (element, data) => {
+            if (element && element.contentWindow) {
+                element.contentWindow.postMessage(data, '*');
+            }
+        },
+
+        // The docs toggle theme by stamping/removing `.dark` on <html> (see App.razor).
+        isDark: () => document.documentElement.classList.contains('dark'),
+
+        // Report light/dark changes to the island so the Monaco editors recolour with the page.
+        // Returns the current theme so the caller can pick the initial editor theme.
+        observeTheme: (dotnetRef) => {
+            const root = document.documentElement;
+            let last = root.classList.contains('dark');
+            themeObserver = new MutationObserver(() => {
+                const now = root.classList.contains('dark');
+                if (now !== last) {
+                    last = now;
+                    dotnetRef.invokeMethodAsync('OnHostThemeChanged', now ? 'dark' : 'light');
+                }
+            });
+            themeObserver.observe(root, { attributes: true, attributeFilter: ['class'] });
+            return last ? 'dark' : 'light';
+        },
+
+        disposeTheme: () => {
+            if (themeObserver) {
+                themeObserver.disconnect();
+                themeObserver = null;
+            }
+        }
+    };
+})();


### PR DESCRIPTION
Add a Tailwind-Play-style playground at /playground: edit HTML with utility
classes and watch the preview and generated CSS recompile live, in the browser,
via the real MonorailCss engine compiled to WebAssembly.

- New MonorailCss.Docs.Client Blazor WASM project holds the PlaygroundIsland
  (Monaco HTML editor + generated-CSS pane + sandboxed iframe preview + per-class
  CSS hover), ported from tests/TryMonorail. DocsTheme rebuilds the site palette
  (sanibel/frosted/mixed/happily + primary/accent/base aliases) with core
  MapColorPalette so the client needs no Pennington server dependency.
- Host wires interactive-WebAssembly components + render mode, references the
  client (bundling its WASM into the static export), and loads Monaco +
  blazor.web.js. data-enhance-nav=false keeps Blazor's nav out of Pennington's
  spa-engine; the Playground link uses data-spa-reload for a clean Monaco boot.
- Full-width PlaygroundLayout reuses a new shared SiteHeader (extracted from
  MainLayout) so the heading and colour scheme match the rest of the docs.
- Add <base href="/"> so Monaco's AMD loader resolves its vs/* modules against
  the document base; Pennington rewrites it to the sub-path on the GitHub Pages
  build, so the modules load under /<repo>/ there too.

The default document is a compact modern card built on the docs palette that
fits the editor window.
