### PR TITLE
fix(docs): set CanonicalBaseUrl so social-card URLs are absolute

### DIFF
--- a/docs/MonorailCss.Docs/Program.cs
+++ b/docs/MonorailCss.Docs/Program.cs
@@ -105,6 +105,15 @@ builder.Services.AddPennington(options =>
 {
     options.SiteTitle = "MonorailCss Documentation";
     options.SiteDescription = "A JIT CSS compiler that aims to be Tailwind CSS 4.3 compatible, written in .NET";
+
+    // The production origin, including the GitHub Pages project subdirectory (the build is
+    // published under `--base-url /MonorailCss.Framework/`, so this must carry that prefix too).
+    // OpenGraph/Twitter crawlers require an absolute og:image URL: without CanonicalBaseUrl the
+    // social-card tags fall back to root-relative paths that work in dev but don't unfurl when
+    // shared — and the base-url rewriter only rewrites href/src, not <meta content>. Setting it
+    // also makes the canonical link, sitemap, and llms.txt URLs absolute.
+    options.CanonicalBaseUrl = "https://monorailcss.github.io/MonorailCss.Framework";
+
     options.ContentRootPath = new Pennington.Routing.FilePath("Content");
 
     // The docs pages: Content/**/*.md bound to the core DocFrontMatter shape, which


### PR DESCRIPTION
## Summary

Follow-up to #108 (social cards). The card `og:image`/`twitter:image` tags were emitting **root-relative** paths (`/social-cards/...png`), which don't work on the GitHub Pages subdirectory deploy.

Two reasons they break in production:

1. **OpenGraph/Twitter crawlers require an absolute `og:image` URL** — they won't resolve a relative path against the page.
2. The static build's `BaseUrlHtmlRewriter` only rewrites `href`/`src`/`data-src`/`action`/`srcset`, **not** `<meta content>`, so the `/MonorailCss.Framework/` prefix was never applied to the card tags either.

This is the documented requirement for Pennington social cards (their own docs and the Ashcroft/Beck sites set it): with `CanonicalBaseUrl` unset, the tags fall back to root-relative paths that work in dev but don't unfurl when shared.

## Change

Set `CanonicalBaseUrl` to the published origin, **including the Pages project subdirectory** (matches the build's `--base-url /MonorailCss.Framework/`):

```csharp
options.CanonicalBaseUrl = "https://monorailcss.github.io/MonorailCss.Framework";
```

Card URLs derive from `CanonicalBaseUrl` (independent of the build base-url), so they're now absolute. Canonical link, sitemap, and llms.txt URLs become absolute too.

## Verification (subdirectory static build)

- `og:image` / `twitter:image` → `https://monorailcss.github.io/MonorailCss.Framework/social-cards/playground.png`
- `canonical` → `https://monorailcss.github.io/MonorailCss.Framework/playground/`
- Regular `href`s still get the `/MonorailCss.Framework/` prefix; no double-prefix on the absolute card URLs; zero leftover root-relative `content="/social-cards/` refs across all pages.

> Note: the origin `https://monorailcss.github.io/MonorailCss.Framework` was inferred from the build base-url + repo path + absence of a CNAME. Adjust if Pages serves under a custom domain.
